### PR TITLE
35 file id regex

### DIFF
--- a/stylesheets/fits-to-preservation.xsl
+++ b/stylesheets/fits-to-preservation.xsl
@@ -66,52 +66,25 @@
     <!--$uri: the unique identifier for the group in the ARCHive (digital preservation system).-->
     <xsl:variable name="uri"><xsl:value-of select="$ns" />/<xsl:value-of select="$department" /></xsl:variable>
          
-    <!--file-id: the portion of the file path beginning with the aip id.-->
+    <!--file-id: the portion of the file path beginning with objects (bmac) or the aip id (all other departments.-->
     <!--Gets the file id from each instance of fits/fileinfo/filepath-->
-    <!--Uses department parameter to determine what pattern to match.-->
     <xsl:template name="get-file-id">
-        <xsl:if test="$department='bmac'">
-            <xsl:analyze-string select="fileinfo/filepath" regex="[\\|/]objects[\\|/](.*)">
-                <xsl:matching-substring>
-                    <xsl:value-of select="regex-group(1)" />
-                </xsl:matching-substring>
+        <xsl:choose>
+            <xsl:when test="$department='bmac'">
+                <xsl:analyze-string select="fileinfo/filepath" regex="[\\|/]objects[\\|/](.*)">
+                    <xsl:matching-substring>
+                        <xsl:value-of select="regex-group(1)" />
+                    </xsl:matching-substring>
+                </xsl:analyze-string>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:analyze-string select="fileinfo/filepath" regex="{$aip-id}.*">
+                    <xsl:matching-substring>
+                        <xsl:value-of select="." />
+                    </xsl:matching-substring>
             </xsl:analyze-string>
-        </xsl:if>
-        <xsl:if test="$department='hargrett'">
-            <xsl:analyze-string select="fileinfo/filepath" regex="(harg|guan)[-|_](ms|ua)?(\d{{2}}-)?([a-z]{{4}}_)?\d{{4}}(er|-web-\d{{6}}-|-)\d{{3,4}}.*">
-                <xsl:matching-substring>
-                    <xsl:value-of select="." />
-                </xsl:matching-substring>
-            </xsl:analyze-string>
-        </xsl:if>
-        <xsl:if test="$department='magil'">
-            <xsl:analyze-string select="fileinfo/filepath" regex="magil-ggp-\d+-\d{{4}}-\d{{2}}.*">
-                <xsl:matching-substring>
-                    <xsl:value-of select="." />
-                </xsl:matching-substring>
-            </xsl:analyze-string>
-        </xsl:if>
-        <xsl:if test="$department='emory'">
-            <xsl:analyze-string select="fileinfo/filepath" regex="emory_[a-z]{{2}}_\d{{2,4}}_\d{{2,4}}.*">
-                <xsl:matching-substring>
-                    <xsl:value-of select="." />
-                </xsl:matching-substring>
-            </xsl:analyze-string>
-        </xsl:if>
-        <xsl:if test="$department='russell'">
-            <xsl:analyze-string select="fileinfo/filepath" regex="rbrl-\d{{3}}-(er|web)-\d{{6}}(-\d{{4}})?.*">
-                <xsl:matching-substring>
-                    <xsl:value-of select="." />
-                </xsl:matching-substring>
-            </xsl:analyze-string>
-        </xsl:if>
-        <xsl:if test="$department='test'">
-            <xsl:analyze-string select="fileinfo/filepath" regex="test-\d{{3}}-er-\d{{6}}.*">
-                <xsl:matching-substring>
-                    <xsl:value-of select="." />
-                </xsl:matching-substring>
-            </xsl:analyze-string>
-        </xsl:if>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
     <!-- File count to use in testing when aips are treated differently if they have one or multiple files.-->

--- a/tests/expected_xml/guan_caes_1234-123_preservation.xml
+++ b/tests/expected_xml/guan_caes_1234-123_preservation.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<preservation xmlns:dc="http://purl.org/dc/terms/"
+              xmlns:premis="http://www.loc.gov/premis/v3">
+   <dc:title>Hargrett Born-Digital Title Variation 1</dc:title>
+   <dc:rights>http://rightsstatements.org/vocab/InC/1.0/</dc:rights>
+   <aip>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>guan_caes_1234-123</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/guan_caes_1234-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>1</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>representation</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:size>331</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Comma-Separated Values (CSV)</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/18</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+            </premis:format>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>ua12-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+   </aip>
+   <filelist>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/guan_caes_1234-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>guan_caes_1234-123/objects/file.txt</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>aaaf7028b8b9c6ce59bd3d1ee80869b3</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>9</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified as valid by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified as well-formed by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>guan_caes_1234-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/guan_caes_1234-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>guan_caes_1234-123/objects/file2.txt</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>3a6b67072d340500cdba69323d0adc69</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>270</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified as valid by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified as well-formed by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>guan_caes_1234-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/guan_caes_1234-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>guan_caes_1234-123/objects/file3.csv</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>d3db0252d110811fe3e0614a40906a4f</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>52</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Comma-Separated Values (CSV)</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/18</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>guan_caes_1234-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+   </filelist>
+</preservation>

--- a/tests/expected_xml/har-ua12-123-123-123_preservation.xml
+++ b/tests/expected_xml/har-ua12-123-123-123_preservation.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<preservation xmlns:dc="http://purl.org/dc/terms/"
+              xmlns:premis="http://www.loc.gov/premis/v3">
+   <dc:title>Hargrett Oral History Title Variation 3</dc:title>
+   <dc:rights>http://rightsstatements.org/vocab/InC/1.0/</dc:rights>
+   <aip>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>har-ua12-123-123-123</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/har-ua12-123-123-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>1</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>representation</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:size>331</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Comma-Separated Values (CSV)</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/18</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+            </premis:format>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>har-ua12-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+   </aip>
+   <filelist>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/har-ua12-123-123-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>har-ua12-123-123-123/objects/file.txt</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>aaaf7028b8b9c6ce59bd3d1ee80869b3</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>9</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified as valid by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified as well-formed by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>har-ua12-123-123-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/har-ua12-123-123-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>har-ua12-123-123-123/objects/file2.txt</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>3a6b67072d340500cdba69323d0adc69</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>270</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified as valid by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified as well-formed by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>har-ua12-123-123-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/har-ua12-123-123-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>har-ua12-123-123-123/objects/file3.csv</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>d3db0252d110811fe3e0614a40906a4f</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>52</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Comma-Separated Values (CSV)</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/18</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>har-ua12-123-123-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+   </filelist>
+</preservation>

--- a/tests/expected_xml/har-ua12-123_1234_media_preservation.xml
+++ b/tests/expected_xml/har-ua12-123_1234_media_preservation.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<preservation xmlns:dc="http://purl.org/dc/terms/"
+              xmlns:premis="http://www.loc.gov/premis/v3">
+   <dc:title>Hargrett Oral History Title Variation 1</dc:title>
+   <dc:rights>http://rightsstatements.org/vocab/InC/1.0/</dc:rights>
+   <aip>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>har-ua12-123_1234_media</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/har-ua12-123_1234_media</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>1</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>representation</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:size>331</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Comma-Separated Values (CSV)</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/18</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+            </premis:format>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>har-ua12-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+   </aip>
+   <filelist>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/har-ua12-123_1234_media</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>har-ua12-123_1234_media/objects/file.txt</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>aaaf7028b8b9c6ce59bd3d1ee80869b3</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>9</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified as valid by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified as well-formed by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>har-ua12-123_1234_media</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/har-ua12-123_1234_media</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>har-ua12-123_1234_media/objects/file2.txt</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>3a6b67072d340500cdba69323d0adc69</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>270</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified as valid by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified as well-formed by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>har-ua12-123_1234_media</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/har-ua12-123_1234_media</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>har-ua12-123_1234_media/objects/file3.csv</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>d3db0252d110811fe3e0614a40906a4f</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>52</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Comma-Separated Values (CSV)</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/18</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>har-ua12-123_1234_media</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+   </filelist>
+</preservation>

--- a/tests/expected_xml/har-ua12-123_1234_metadata_preservation.xml
+++ b/tests/expected_xml/har-ua12-123_1234_metadata_preservation.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<preservation xmlns:dc="http://purl.org/dc/terms/"
+              xmlns:premis="http://www.loc.gov/premis/v3">
+   <dc:title>Hargrett Oral History Title Variation 2</dc:title>
+   <dc:rights>http://rightsstatements.org/vocab/InC/1.0/</dc:rights>
+   <aip>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>har-ua12-123_1234_metadata</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/har-ua12-123_1234_metadata</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>1</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>representation</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:size>331</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Comma-Separated Values (CSV)</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/18</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+            </premis:format>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>har-ua12-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+   </aip>
+   <filelist>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/har-ua12-123_1234_metadata</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>har-ua12-123_1234_metadata/objects/file.txt</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>aaaf7028b8b9c6ce59bd3d1ee80869b3</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>9</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified as valid by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified as well-formed by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>har-ua12-123_1234_metadata</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/har-ua12-123_1234_metadata</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>har-ua12-123_1234_metadata/objects/file2.txt</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>3a6b67072d340500cdba69323d0adc69</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>270</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified as valid by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified as well-formed by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>har-ua12-123_1234_metadata</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/har-ua12-123_1234_metadata</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>har-ua12-123_1234_metadata/objects/file3.csv</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>d3db0252d110811fe3e0614a40906a4f</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>52</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Comma-Separated Values (CSV)</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/18</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>har-ua12-123_1234_metadata</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+   </filelist>
+</preservation>

--- a/tests/expected_xml/harg-ms1234-123-123_preservation.xml
+++ b/tests/expected_xml/harg-ms1234-123-123_preservation.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<preservation xmlns:dc="http://purl.org/dc/terms/"
+              xmlns:premis="http://www.loc.gov/premis/v3">
+   <dc:title>Hargrett Born-Digital Title Variation 2</dc:title>
+   <dc:rights>http://rightsstatements.org/vocab/InC/1.0/</dc:rights>
+   <aip>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>harg-ms1234-123-123</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234-123-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>1</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>representation</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:size>331</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Comma-Separated Values (CSV)</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/18</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+            </premis:format>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>harg-ms1234</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+   </aip>
+   <filelist>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234-123-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>harg-ms1234-123-123/objects/file.txt</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>aaaf7028b8b9c6ce59bd3d1ee80869b3</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>9</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified as valid by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified as well-formed by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>harg-ms1234-123-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234-123-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>harg-ms1234-123-123/objects/file2.txt</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>3a6b67072d340500cdba69323d0adc69</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>270</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified as valid by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified as well-formed by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>harg-ms1234-123-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234-123-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>harg-ms1234-123-123/objects/file3.csv</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>d3db0252d110811fe3e0614a40906a4f</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>52</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Comma-Separated Values (CSV)</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/18</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>harg-ms1234-123-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+   </filelist>
+</preservation>

--- a/tests/expected_xml/harg-ms1234-123a-123_preservation.xml
+++ b/tests/expected_xml/harg-ms1234-123a-123_preservation.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<preservation xmlns:dc="http://purl.org/dc/terms/"
+              xmlns:premis="http://www.loc.gov/premis/v3">
+   <dc:title>Hargrett Born-Digital Title Variation 3</dc:title>
+   <dc:rights>http://rightsstatements.org/vocab/InC/1.0/</dc:rights>
+   <aip>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>harg-ms1234-123a-123</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234-123a-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>1</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>representation</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:size>331</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Comma-Separated Values (CSV)</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/18</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+            </premis:format>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>harg-ms1234</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+   </aip>
+   <filelist>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234-123a-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>harg-ms1234-123a-123/objects/file.txt</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>aaaf7028b8b9c6ce59bd3d1ee80869b3</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>9</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified as valid by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified as well-formed by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>harg-ms1234-123a-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234-123a-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>harg-ms1234-123a-123/objects/file2.txt</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>3a6b67072d340500cdba69323d0adc69</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>270</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified as valid by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified as well-formed by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>harg-ms1234-123a-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234-123a-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>harg-ms1234-123a-123/objects/file3.csv</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>d3db0252d110811fe3e0614a40906a4f</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>52</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Comma-Separated Values (CSV)</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/18</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>harg-ms1234-123a-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+   </filelist>
+</preservation>

--- a/tests/expected_xml/harg-ms1234a-123-123_preservation.xml
+++ b/tests/expected_xml/harg-ms1234a-123-123_preservation.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<preservation xmlns:dc="http://purl.org/dc/terms/"
+              xmlns:premis="http://www.loc.gov/premis/v3">
+   <dc:title>Hargrett Born-Digital Title Variation 4</dc:title>
+   <dc:rights>http://rightsstatements.org/vocab/InC/1.0/</dc:rights>
+   <aip>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>harg-ms1234a-123-123</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234a-123-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>1</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>representation</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:size>331</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Comma-Separated Values (CSV)</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/18</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+            </premis:format>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>harg-ms1234</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+   </aip>
+   <filelist>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234a-123-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>harg-ms1234a-123-123/objects/file.txt</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>aaaf7028b8b9c6ce59bd3d1ee80869b3</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>9</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified as valid by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified as well-formed by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>harg-ms1234a-123-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234a-123-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>harg-ms1234a-123-123/objects/file2.txt</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>3a6b67072d340500cdba69323d0adc69</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>270</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Plain text</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/111</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified as valid by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified as well-formed by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+               <premis:formatNote>Format identified by Jhove version 1.20.1</premis:formatNote>
+               <premis:formatNote>Format identified by file utility version 5.03</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>harg-ms1234a-123-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234a-123-123</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>harg-ms1234a-123-123/objects/file3.csv</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:fixity>
+               <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+               <premis:messageDigest>d3db0252d110811fe3e0614a40906a4f</premis:messageDigest>
+               <premis:messageDigestOriginator>OIS File Information version 1.0</premis:messageDigestOriginator>
+            </premis:fixity>
+            <premis:size>52</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Comma-Separated Values (CSV)</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/18</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>harg-ms1234a-123-123</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+   </filelist>
+</preservation>

--- a/tests/expected_xml/harg-ms1234er1234_preservation.xml
+++ b/tests/expected_xml/harg-ms1234er1234_preservation.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <preservation xmlns:dc="http://purl.org/dc/terms/"
               xmlns:premis="http://www.loc.gov/premis/v3">
-   <dc:title>Hargrett Born-Digital Title</dc:title>
+   <dc:title>Hargrett Born-Digital Title Variation 5</dc:title>
    <dc:rights>http://rightsstatements.org/vocab/InC/1.0/</dc:rights>
    <aip>
       <premis:object>
          <premis:objectIdentifier>
             <premis:objectIdentifierType>http://uri/hargrett</premis:objectIdentifierType>
-            <premis:objectIdentifierValue>harg-ms3786er0002</premis:objectIdentifierValue>
+            <premis:objectIdentifierValue>harg-ms1234er1234</premis:objectIdentifierValue>
          </premis:objectIdentifier>
          <premis:objectIdentifier>
-            <premis:objectIdentifierType>http://uri/hargrett/harg-ms3786er0002</premis:objectIdentifierType>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234er1234</premis:objectIdentifierType>
             <premis:objectIdentifierValue>1</premis:objectIdentifierValue>
          </premis:objectIdentifier>
          <premis:objectCategory>representation</premis:objectCategory>
@@ -46,7 +46,7 @@
             <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
             <premis:relatedObjectIdentifier>
                <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
-               <premis:relatedObjectIdentifierValue>harg-ms3786</premis:relatedObjectIdentifierValue>
+               <premis:relatedObjectIdentifierValue>harg-ms1234</premis:relatedObjectIdentifierValue>
             </premis:relatedObjectIdentifier>
          </premis:relationship>
       </premis:object>
@@ -54,8 +54,8 @@
    <filelist>
       <premis:object>
          <premis:objectIdentifier>
-            <premis:objectIdentifierType>http://uri/hargrett/harg-ms3786er0002</premis:objectIdentifierType>
-            <premis:objectIdentifierValue>harg-ms3786er0002/objects/file.txt</premis:objectIdentifierValue>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234er1234</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>harg-ms1234er1234/objects/file.txt</premis:objectIdentifierValue>
          </premis:objectIdentifier>
          <premis:objectCategory>file</premis:objectCategory>
          <premis:objectCharacteristics>
@@ -86,14 +86,14 @@
             <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
             <premis:relatedObjectIdentifier>
                <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
-               <premis:relatedObjectIdentifierValue>harg-ms3786er0002</premis:relatedObjectIdentifierValue>
+               <premis:relatedObjectIdentifierValue>harg-ms1234er1234</premis:relatedObjectIdentifierValue>
             </premis:relatedObjectIdentifier>
          </premis:relationship>
       </premis:object>
       <premis:object>
          <premis:objectIdentifier>
-            <premis:objectIdentifierType>http://uri/hargrett/harg-ms3786er0002</premis:objectIdentifierType>
-            <premis:objectIdentifierValue>harg-ms3786er0002/objects/file2.txt</premis:objectIdentifierValue>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234er1234</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>harg-ms1234er1234/objects/file2.txt</premis:objectIdentifierValue>
          </premis:objectIdentifier>
          <premis:objectCategory>file</premis:objectCategory>
          <premis:objectCharacteristics>
@@ -124,14 +124,14 @@
             <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
             <premis:relatedObjectIdentifier>
                <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
-               <premis:relatedObjectIdentifierValue>harg-ms3786er0002</premis:relatedObjectIdentifierValue>
+               <premis:relatedObjectIdentifierValue>harg-ms1234er1234</premis:relatedObjectIdentifierValue>
             </premis:relatedObjectIdentifier>
          </premis:relationship>
       </premis:object>
       <premis:object>
          <premis:objectIdentifier>
-            <premis:objectIdentifierType>http://uri/hargrett/harg-ms3786er0002</premis:objectIdentifierType>
-            <premis:objectIdentifierValue>harg-ms3786er0002/objects/file3.csv</premis:objectIdentifierValue>
+            <premis:objectIdentifierType>http://uri/hargrett/harg-ms1234er1234</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>harg-ms1234er1234/objects/file3.csv</premis:objectIdentifierValue>
          </premis:objectIdentifier>
          <premis:objectCategory>file</premis:objectCategory>
          <premis:objectCharacteristics>
@@ -158,7 +158,7 @@
             <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
             <premis:relatedObjectIdentifier>
                <premis:relatedObjectIdentifierType>http://uri/hargrett</premis:relatedObjectIdentifierType>
-               <premis:relatedObjectIdentifierValue>harg-ms3786er0002</premis:relatedObjectIdentifierValue>
+               <premis:relatedObjectIdentifierValue>harg-ms1234er1234</premis:relatedObjectIdentifierValue>
             </premis:relatedObjectIdentifier>
          </premis:relationship>
       </premis:object>

--- a/tests/test_make_preservation_xml.py
+++ b/tests/test_make_preservation_xml.py
@@ -16,10 +16,18 @@ def make_test_input(aip):
     and gets it ready for running the make_preservation_xml function.
     """
 
-    # Makes the AIP folder and test files to use as the AIP content.
-    # For a born-digital AIP (identifier contains er), makes two text files and a csv.
+    # Makes the AIP folder.
     os.mkdir(aip.id)
-    if "er" in aip.id:
+
+    # Makes the test files.
+    # For a web AIP, makes a file with a WARC extension.
+    # Since it is not really a WARC, the format identification will be Unknown Binary.
+    if "web" in aip.id or aip.id.startswith("magil-ggp"):
+        with open(os.path.join(aip.id, "file.warc"), "w") as file:
+            file.write("Placeholder for a warc file")
+    # For other AIPs, makes two text files and a csv.
+    # Oral histories wouldn't have these formats but may have multiple files, so this is good enough for now.
+    else:
         with open(os.path.join(aip.id, "file.txt"), "w") as file:
             file.write("Test text")
         with open(os.path.join(aip.id, "file2.txt"), "w") as file2:
@@ -27,12 +35,6 @@ def make_test_input(aip):
         with open(os.path.join(aip.id, "file3.csv"), "w") as file3:
             file3.write("test,test,test,test,test\n")
             file3.write("test,test,test,test,test\n")
-    # For a web AIP (currently the only other type using this script),
-    # makes a file with a WARC extension.
-    # Since it is not really a WARC, the format identification will be Unknown Binary.
-    else:
-        with open(os.path.join(aip.id, "file.warc"), "w") as file:
-            file.write("Placeholder for a warc file")
 
     # Runs the functions for the earlier workflow steps so there is FITS data ready to make into a preservation.xml
     make_output_directories()
@@ -65,7 +67,9 @@ class TestMakePreservationXML(unittest.TestCase):
         """
 
         # Deletes any AIP folder, which would be in the current directory.
-        aip_ids = ("error-id", "harg-0000-web-202108-0001", "harg-ms3786er0002", "harg-ms3786-web-202108-0001",
+        aip_ids = ("error-id", "guan_caes_1234-123", "har-ua12-123_1234_media", "har-ua12-123_1234_metadata",
+                   "har-ua12-123-123-123", "harg-0000-web-202108-0001", "harg-ms1234-123-123",
+                   "harg-ms1234-123a-123", "harg-ms1234a-123-123", "harg-ms1234er1234", "harg-ms3786-web-202108-0001",
                    "har-ua20-002-web-202108-0001", "magil-ggp-2472041-2022-05", "rbrl-000-web-202102-0001",
                    "rbrl-025-er-000018", "rbrl-043-web-202102-0001")
         for aip_folder in aip_ids:
@@ -82,14 +86,14 @@ class TestMakePreservationXML(unittest.TestCase):
             if os.path.exists(path):
                 shutil.rmtree(path)
 
-    def test_born_digital_hargrett(self):
+    def test_born_digital_hargrett_1(self):
         """
         Test for making the preservation.xml file for a Hargrett born-digital AIP.
         """
         # Makes the input needed for the function (AIP class instance and AIP folder with test files),
         # and runs the function.
-        aip = AIP(os.getcwd(), "hargrett", "harg-ms3786", "harg-ms3786er0002", "harg-ms3786er0002",
-                  "Hargrett Born-Digital Title", 1, True)
+        aip = AIP(os.getcwd(), "hargrett", "ua12-123", "guan_caes_1234-123", "guan_caes_1234-123",
+                  "Hargrett Born-Digital Title Variation 1", 1, True)
         make_test_input(aip)
         make_preservation_xml(aip)
 
@@ -98,7 +102,79 @@ class TestMakePreservationXML(unittest.TestCase):
         result = read_preservation_xml(aip.id)
         with open(os.path.join("expected_xml", f"{aip.id}_preservation.xml"), "r") as expected_file:
             expected = expected_file.read()
-        self.assertEqual(result, expected, "Problem with test for Hargrett born-digital")
+        self.assertEqual(result, expected, "Problem with test for Hargrett born-digital, variation 1")
+
+    def test_born_digital_hargrett_2(self):
+        """
+        Test for making the preservation.xml file for a Hargrett born-digital AIP.
+        """
+        # Makes the input needed for the function (AIP class instance and AIP folder with test files),
+        # and runs the function.
+        aip = AIP(os.getcwd(), "hargrett", "harg-ms1234", "harg-ms1234-123-123", "harg-ms1234-123-123",
+                  "Hargrett Born-Digital Title Variation 2", 1, True)
+        make_test_input(aip)
+        make_preservation_xml(aip)
+
+        # Test for the preservation.xml file.
+        # The expected value is stored in the test folder of this script repo.
+        result = read_preservation_xml(aip.id)
+        with open(os.path.join("expected_xml", f"{aip.id}_preservation.xml"), "r") as expected_file:
+            expected = expected_file.read()
+        self.assertEqual(result, expected, "Problem with test for Hargrett born-digital, variation 2")
+
+    def test_born_digital_hargrett_3(self):
+        """
+        Test for making the preservation.xml file for a Hargrett born-digital AIP.
+        """
+        # Makes the input needed for the function (AIP class instance and AIP folder with test files),
+        # and runs the function.
+        aip = AIP(os.getcwd(), "hargrett", "harg-ms1234", "harg-ms1234-123a-123", "harg-ms1234-123a-123",
+                  "Hargrett Born-Digital Title Variation 3", 1, True)
+        make_test_input(aip)
+        make_preservation_xml(aip)
+
+        # Test for the preservation.xml file.
+        # The expected value is stored in the test folder of this script repo.
+        result = read_preservation_xml(aip.id)
+        with open(os.path.join("expected_xml", f"{aip.id}_preservation.xml"), "r") as expected_file:
+            expected = expected_file.read()
+        self.assertEqual(result, expected, "Problem with test for Hargrett born-digital, variation 3")
+
+    def test_born_digital_hargrett_4(self):
+        """
+        Test for making the preservation.xml file for a Hargrett born-digital AIP.
+        """
+        # Makes the input needed for the function (AIP class instance and AIP folder with test files),
+        # and runs the function.
+        aip = AIP(os.getcwd(), "hargrett", "harg-ms1234", "harg-ms1234a-123-123", "harg-ms1234a-123-123",
+                  "Hargrett Born-Digital Title Variation 4", 1, True)
+        make_test_input(aip)
+        make_preservation_xml(aip)
+
+        # Test for the preservation.xml file.
+        # The expected value is stored in the test folder of this script repo.
+        result = read_preservation_xml(aip.id)
+        with open(os.path.join("expected_xml", f"{aip.id}_preservation.xml"), "r") as expected_file:
+            expected = expected_file.read()
+        self.assertEqual(result, expected, "Problem with test for Hargrett born-digital, variation 4")
+
+    def test_born_digital_hargrett_5(self):
+        """
+        Test for making the preservation.xml file for a Hargrett born-digital AIP.
+        """
+        # Makes the input needed for the function (AIP class instance and AIP folder with test files),
+        # and runs the function.
+        aip = AIP(os.getcwd(), "hargrett", "harg-ms1234", "harg-ms1234er1234", "harg-ms1234er1234",
+                  "Hargrett Born-Digital Title Variation 5", 1, True)
+        make_test_input(aip)
+        make_preservation_xml(aip)
+
+        # Test for the preservation.xml file.
+        # The expected value is stored in the test folder of this script repo.
+        result = read_preservation_xml(aip.id)
+        with open(os.path.join("expected_xml", f"{aip.id}_preservation.xml"), "r") as expected_file:
+            expected = expected_file.read()
+        self.assertEqual(result, expected, "Problem with test for Hargrett born-digital, variation 5")
 
     def test_born_digital_russell(self):
         """
@@ -146,6 +222,60 @@ class TestMakePreservationXML(unittest.TestCase):
         result_log2 = aip.log["Complete"]
         expected_log2 = "Error during processing"
         self.assertEqual(result_log2, expected_log2, "Problem with test for error handling, log: Complete")
+
+    def test_oral_history_hargrett_1(self):
+        """
+        Test for making the preservation.xml file for a Hargrett oral history AIP.
+        """
+        # Makes the input needed for the function (AIP class instance and AIP folder with test files),
+        # and runs the function.
+        aip = AIP(os.getcwd(), "hargrett", "har-ua12-123", "har-ua12-123_1234_media", "har-ua12-123_1234_media",
+                  "Hargrett Oral History Title Variation 1", 1, True)
+        make_test_input(aip)
+        make_preservation_xml(aip)
+
+        # Test for the preservation.xml file.
+        # The expected value is stored in the test folder of this script repo.
+        result = read_preservation_xml(aip.id)
+        with open(os.path.join("expected_xml", f"{aip.id}_preservation.xml"), "r") as expected_file:
+            expected = expected_file.read()
+        self.assertEqual(result, expected, "Problem with test for Hargrett oral history, variation 1")
+
+    def test_oral_history_hargrett_2(self):
+        """
+        Test for making the preservation.xml file for a Hargrett oral history AIP.
+        """
+        # Makes the input needed for the function (AIP class instance and AIP folder with test files),
+        # and runs the function.
+        aip = AIP(os.getcwd(), "hargrett", "har-ua12-123", "har-ua12-123_1234_metadata", "har-ua12-123_1234_metadata",
+                  "Hargrett Oral History Title Variation 2", 1, True)
+        make_test_input(aip)
+        make_preservation_xml(aip)
+
+        # Test for the preservation.xml file.
+        # The expected value is stored in the test folder of this script repo.
+        result = read_preservation_xml(aip.id)
+        with open(os.path.join("expected_xml", f"{aip.id}_preservation.xml"), "r") as expected_file:
+            expected = expected_file.read()
+        self.assertEqual(result, expected, "Problem with test for Hargrett oral history, variation 2")
+
+    def test_oral_history_hargrett_3(self):
+        """
+        Test for making the preservation.xml file for a Hargrett oral history AIP.
+        """
+        # Makes the input needed for the function (AIP class instance and AIP folder with test files),
+        # and runs the function.
+        aip = AIP(os.getcwd(), "hargrett", "har-ua12-123", "har-ua12-123-123-123", "har-ua12-123-123-123",
+                  "Hargrett Oral History Title Variation 3", 1, True)
+        make_test_input(aip)
+        make_preservation_xml(aip)
+
+        # Test for the preservation.xml file.
+        # The expected value is stored in the test folder of this script repo.
+        result = read_preservation_xml(aip.id)
+        with open(os.path.join("expected_xml", f"{aip.id}_preservation.xml"), "r") as expected_file:
+            expected = expected_file.read()
+        self.assertEqual(result, expected, "Problem with test for Hargrett oral history, variation 3")
 
     def test_web_hargrett(self):
         """


### PR DESCRIPTION
In the fits-to-preservation stylesheet, use the aip-id parameter to extract the file-id from the file path instead of using regex to define the pattern. This way, new aip-id patterns can be added without impacting the script.