### PR TITLE
34 test if fits directory matches input

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ To run the script via the command line: python /path/general_aip.py aips_directo
 Includes one test file per function, and a test to run the full script.
 Unit test scripts should be run with the script repo folder "tests" as the current working directory.
 
+Before running test_check_configuration.py, rename the configuration_test.py file in the tests folder to configuration.py
+and rename it back to configuration_test.py once the test is complete.
+Otherwise, the wrong configuration.py is used for all other tests.
+
 Known issue: Tests that check the contents of XML may fail due to the inconsistent order of element attributes.
 
 ## Workflow

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -108,6 +108,9 @@ def check_configuration(aips_dir):
     try:
         if not os.path.exists(c.FITS):
             errors_list.append(f"FITS path '{c.FITS}' is not correct.")
+        # For FITS, checks that the directory (first character) of the path matches the directory of aips_dir.
+        if not c.FITS[0] == aips_dir[0]:
+            errors_list.append(f"FITS is not in the same directory as the aips_directory '{aips_dir}'.")
     except AttributeError:
         errors_list.append("FITS variable is missing from the configuration file.")
 

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -86,13 +86,15 @@ def check_arguments(arguments):
     return aips_directory, to_zip, aip_metadata_csv, errors_list
 
 
-def check_configuration():
+def check_configuration(aips_dir):
     """Verify the variables in the configuration file are correct
 
     - All variables are present
     - Path variables are a valid path
+    - FITS path starts with the same letter as the aips_directory
 
-    Parameters: none
+    Parameters:
+        aips_dir : the path to the folder which contains the folders to be made into AIPs
 
     Returns:
         errors_list : a list of errors, or an empty list if there were no errors

--- a/general_aip.py
+++ b/general_aip.py
@@ -38,7 +38,7 @@ os.chdir(AIPS_DIRECTORY)
 # Verifies all the variables from the configuration file are present, all the paths are valid,
 # and the FITS path is in the same letter directory as AIPS_DIRECTORY.
 # If not, ends the script.
-configuration_errors = a.check_configuration()
+configuration_errors = a.check_configuration(AIPS_DIRECTORY)
 if len(configuration_errors) > 0:
     print('\nProblems detected with configuration.py:')
     for error in configuration_errors:

--- a/general_aip.py
+++ b/general_aip.py
@@ -35,7 +35,8 @@ if len(argument_errors) > 0:
 # Makes the current directory the AIPs directory.
 os.chdir(AIPS_DIRECTORY)
 
-# Verifies all the variables from the configuration file are present and all the paths are valid.
+# Verifies all the variables from the configuration file are present, all the paths are valid,
+# and the FITS path is in the same letter directory as AIPS_DIRECTORY.
 # If not, ends the script.
 configuration_errors = a.check_configuration()
 if len(configuration_errors) > 0:

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -1,0 +1,18 @@
+"""For initial unit testing experiment"""
+
+# Path variables.
+
+# Path does not exist and letter directory does not match AIPS directory.
+FITS = 'Z:\\FITS\\fits.bat'
+
+# Path does not exist.
+SAXON = 'Z:\\Programs\\SaxonHE10-5J\\saxon-he-10.5.jar'
+
+# Missing variable MD5DEEP
+
+# Path exists
+STYLESHEETS = '..\\stylesheets'
+
+# Non-path variables
+# Missing GROUPS
+NAMESPACE = 'https://namespace.edu'

--- a/tests/test_check_configuration.py
+++ b/tests/test_check_configuration.py
@@ -1,0 +1,32 @@
+"""Testing for the function check_configuration, which tests the correctness of configuration.py.
+
+Before running this test, rename the file tests/configuration_tests.py to tests/configuration.py
+and after running this test, rename it back.
+Otherwise, this configuration.py will be used for the other unit tests, causing all kinds of errors.
+
+Since variables from configuration.py are imported when check_configuration is imported,
+we haven't yet figured out how to test on variations of configuration.py.
+Instead, this test has at least one of each possible error
+and at least one of each variable type (path and not path) that is correct.
+"""
+import os
+import unittest
+from aip_functions import check_configuration
+
+
+class MyTestCase(unittest.TestCase):
+    def test_function(self):
+        """
+        Preliminary test for the function. See note above for details.
+        """
+        errors_list = check_configuration(os.getcwd())
+        expected = ["FITS path 'Z:\\FITS\\fits.bat' is not correct.",
+                    f"FITS is not in the same directory as the aips_directory '{os.getcwd()}'.",
+                    "SAXON path 'Z:\\Programs\\SaxonHE10-5J\\saxon-he-10.5.jar' is not correct.",
+                    "MD5DEEP variable is missing from the configuration file.",
+                    "GROUPS variable is missing from the configuration file."]
+        self.assertEqual(errors_list, expected, "Problem with test for check_configuration function")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
As part of check_configuration(), verify that the letter directory of FITS matches the letter directory of the input directory (aips_directory). If they don't, it causes an error mid-way through the script.