### PR TITLE
39 rights validation for preservationxml is too strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ For UGA, these values are:
 * Title: AIP title
 * Version: AIP version number, which must be a whole number
 
+### Changing Rights Statements
+
+By default, the fits-to-preservation.xsl stylesheet will assign http://rightsstatements.org/vocab/InC/1.0/ to the AIPs.
+To change this, edit the stylesheet prior to running the script.
+There must be one rightstatement.org or Creative Commons license.
+
+For additional rights, add one <dc:rights> element per rights statement.
+The right must be added to our preservation system (ARCHive) first.
+The element value is the objectIdentifierType/objectIdentifierValue from our preservation system.
+
 ### Script Arguments
 
 To run the script via the command line: python /path/general_aip.py aips_directory [no-zip]

--- a/stylesheets/dc.xsd
+++ b/stylesheets/dc.xsd
@@ -17,9 +17,9 @@
 
 	<xs:element name="rights">
 		<xs:simpleType>
-			<!--must use rightsstatement.org statement or creative commons license-->
+			<!--must use a URI, with rightsstatement.org statement or creative commons license required but local also permitted-->
 			<xs:restriction base="xs:anyURI">
-				<xs:pattern value="(http://rightsstatements.org/vocab/).+|(https://creativecommons.org/licenses/).+" />
+				<xs:pattern value="(http).+" />
 			</xs:restriction>
 		</xs:simpleType>
 	</xs:element>

--- a/stylesheets/preservation.xsd
+++ b/stylesheets/preservation.xsd
@@ -14,7 +14,7 @@
         <xs:complexType>
             <xs:sequence>
                <xs:element ref="dc:title" />
-                <xs:element ref="dc:rights" />
+                <xs:element ref="dc:rights" maxOccurs="unbounded"/>
                 <xs:element name="aip">
                     <xs:complexType>
                         <xs:sequence><xs:element ref="premis:object" /></xs:sequence>

--- a/tests/test-coll999-er3/metadata/test-coll999-er3_preservation.xml
+++ b/tests/test-coll999-er3/metadata/test-coll999-er3_preservation.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<preservation xmlns:dc="http://purl.org/dc/terms/"
+              xmlns:premis="http://www.loc.gov/premis/v3">
+   <dc:title>title</dc:title>
+   <dc:rights>http://rightsstatements.org/vocab/InC/1.0/</dc:rights>
+   <dc:rights>http://local/test/rights1</dc:rights>
+   <dc:rights>http://local/test/rights2</dc:rights>
+   <aip>
+      <premis:object>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://local/test</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>test-coll999-er3</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectIdentifier>
+            <premis:objectIdentifierType>http://local/test/test-coll999-er3</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>1</premis:objectIdentifierValue>
+         </premis:objectIdentifier>
+         <premis:objectCategory>file</premis:objectCategory>
+         <premis:objectCharacteristics>
+            <premis:size>1265</premis:size>
+            <premis:format>
+               <premis:formatDesignation>
+                  <premis:formatName>Comma-Separated Values (CSV)</premis:formatName>
+               </premis:formatDesignation>
+               <premis:formatRegistry>
+                  <premis:formatRegistryName>https://www.nationalarchives.gov.uk/PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey>x-fmt/18</premis:formatRegistryKey>
+                  <premis:formatRegistryRole>specification</premis:formatRegistryRole>
+               </premis:formatRegistry>
+               <premis:formatNote>Format identified by Droid version 6.4</premis:formatNote>
+            </premis:format>
+         </premis:objectCharacteristics>
+         <premis:relationship>
+            <premis:relationshipType>structural</premis:relationshipType>
+            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
+            <premis:relatedObjectIdentifier>
+               <premis:relatedObjectIdentifierType>http://local/test</premis:relatedObjectIdentifierType>
+               <premis:relatedObjectIdentifierValue>coll999</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+         </premis:relationship>
+      </premis:object>
+   </aip>
+</preservation>

--- a/tests/test_validate_preservation_xml.py
+++ b/tests/test_validate_preservation_xml.py
@@ -64,6 +64,28 @@ class TestValidatePreservationXML(unittest.TestCase):
         expected_valid = f"Preservation.xml valid on {datetime.date.today()}"
         self.assertEqual(result_valid, expected_valid, "Problem with valid, log: PresValid")
 
+    def test_valid_multiple_rights(self):
+        """
+        Test for successfully validating the preservation.xml file with multiple rights statements.
+        It includes a required rightsstatement.org and an optional local rights statement.
+        This test was made later and follows a more recent structure (using a pre-existing file)
+        rather than running the other functions. The other tests will be updated later.
+        """
+        # Runs the function being tested.
+        aip = AIP(os.getcwd(), "test", "coll999", "aip-folder", "test-coll999-er3", "title", 1, True)
+        validate_preservation_xml(aip)
+
+        # Test for the AIP Log: preservation.xml is made.
+        result_presxml = aip.log["PresXML"]
+        expected_presxml = "Successfully created preservation.xml"
+        self.assertEqual(result_presxml, expected_presxml, "Problem with valid with multiple rights, log: PresXML")
+
+        # Test for the AIP Log: preservation.xml is valid.
+        # Removes the timestamp (last 16 characters) from result for a consistent expected value.
+        result_valid = aip.log["PresValid"][:-16]
+        expected_valid = f"Preservation.xml valid on {datetime.date.today()}"
+        self.assertEqual(result_valid, expected_valid, "Problem with valid with multiple rights, log: PresValid")
+
     def test_error_missing(self):
         """
         Test for error handling if the preservation.xml file is missing during validation.


### PR DESCRIPTION
Update rights validation to allow the field to repeat and to be any URI, not just RightsStatement.org and Creative Commons. This allows the optional use of local rights statements.