### PR TITLE
AV check_metadata_csv()

### DIFF
--- a/aip_functions.py
+++ b/aip_functions.py
@@ -180,7 +180,7 @@ def check_configuration(aips_dir):
     return errors_list
 
 
-def check_metadata_csv(read_metadata):
+def check_metadata_csv(read_metadata, aips_dir):
     """Verify the content of the metadata.csv is correct
 
     - Columns are in the required order
@@ -190,6 +190,7 @@ def check_metadata_csv(read_metadata):
 
     Parameters:
         read_metadata : contents of the metadata.csv file, read with the csv library
+        aips_dir : the path to the folder which contains the folders to be made into AIPs
 
     Returns:
         errors_list : a list of errors, or an empty list if there were no errors
@@ -227,8 +228,8 @@ def check_metadata_csv(read_metadata):
 
     # Makes a list of every folder name in the AIPs directory.
     aips_directory_list = []
-    for item in os.listdir("."):
-        if os.path.isdir(item):
+    for item in os.listdir(aips_dir):
+        if os.path.isdir(os.path.join(aips_dir, item)):
             aips_directory_list.append(item)
 
     # Checks for any folder names that are in the CSV more than once.
@@ -239,19 +240,19 @@ def check_metadata_csv(read_metadata):
         for duplicate in unique_duplicates:
             errors_list.append(f"{duplicate} is in the metadata.csv folder column more than once.")
 
-    # Checks for any AIPs that are only in the CSV.
+    # Checks for any folders that are only in the CSV.
     just_csv = list(set(csv_folder_list) - set(aips_directory_list))
     if len(just_csv) > 0:
         just_csv.sort()
-        for aip in just_csv:
-            errors_list.append(f"{aip} is in metadata.csv and missing from the AIPs directory.")
+        for aip_folder in just_csv:
+            errors_list.append(f"{aip_folder} is in metadata.csv and missing from the AIPs directory.")
 
-    # Checks for any AIPs that are only in the AIPs directory.
+    # Checks for any folders that are only in the AIPs directory.
     just_aip_dir = list(set(aips_directory_list) - set(csv_folder_list))
     if len(just_aip_dir) > 0:
         just_aip_dir.sort()
-        for aip in just_aip_dir:
-            errors_list.append(f"{aip} is in the AIPs directory and missing from metadata.csv.")
+        for aip_folder in just_aip_dir:
+            errors_list.append(f"{aip_folder} is in the AIPs directory and missing from metadata.csv.")
 
     # The errors list is empty if there were no errors.
     return errors_list

--- a/tests/check_metadata_csv/aip-1/placeholder-for-aip.txt
+++ b/tests/check_metadata_csv/aip-1/placeholder-for-aip.txt
@@ -1,0 +1,2 @@
+AIP contents are not needed for this test.
+It just verifies if the folder is there.

--- a/tests/check_metadata_csv/aip-2/placeholder-for-aip.txt
+++ b/tests/check_metadata_csv/aip-2/placeholder-for-aip.txt
@@ -1,0 +1,2 @@
+AIP contents are not needed for this test.
+It just verifies if the folder is there.

--- a/tests/check_metadata_csv/aip-3/placeholder-for-aip.txt
+++ b/tests/check_metadata_csv/aip-3/placeholder-for-aip.txt
@@ -1,0 +1,2 @@
+AIP contents are not needed for this test.
+It just verifies if the folder is there.

--- a/tests/check_metadata_csv/correct_diff_case_metadata.csv
+++ b/tests/check_metadata_csv/correct_diff_case_metadata.csv
@@ -1,0 +1,4 @@
+department,COLLECTION,folder,aip_id,TITLE,version
+test,test-coll,aip-1,aip-001,title-1,1
+test,test-coll,aip-2,aip-002,title-2,1
+test,test-coll,aip-3,aip-003,title-3,1

--- a/tests/check_metadata_csv/correct_same_case_metadata.csv
+++ b/tests/check_metadata_csv/correct_same_case_metadata.csv
@@ -1,0 +1,4 @@
+Department,Collection,Folder,AIP_ID,Title,Version
+test,test-coll,aip-1,aip-001,title-1,1
+test,test-coll,aip-2,aip-002,title-2,1
+test,test-coll,aip-3,aip-003,title-3,1

--- a/tests/check_metadata_csv/error_column_order_metadata.csv
+++ b/tests/check_metadata_csv/error_column_order_metadata.csv
@@ -1,0 +1,4 @@
+AIP_ID,Department,Collection,Folder,Title,Version
+aip-001,test,test-coll,aip-1,title-1,1
+aip-002,test,test-coll,aip-2,title-2,1
+aip-003,test,test-coll,aip-3,title-3,1

--- a/tests/check_metadata_csv/error_csv_only_metadata.csv
+++ b/tests/check_metadata_csv/error_csv_only_metadata.csv
@@ -1,0 +1,6 @@
+Department,Collection,Folder,AIP_ID,Title,Version
+test,test-coll,aip-1,aip-001,title-1,1
+test,test-coll,aip-2,aip-002,title-2,1
+test,test-coll,aip-3,aip-003,title-3,1
+test,test-coll,aip-4,aip-004,title-4,1
+test,test-coll,aip-5,aip-005,title-5,1

--- a/tests/check_metadata_csv/error_directory_only_metadata.csv
+++ b/tests/check_metadata_csv/error_directory_only_metadata.csv
@@ -1,0 +1,2 @@
+Department,Collection,Folder,AIP_ID,Title,Version
+test,test-coll,aip-2,aip-002,title-2,1

--- a/tests/check_metadata_csv/error_group_metadata.csv
+++ b/tests/check_metadata_csv/error_group_metadata.csv
@@ -1,0 +1,4 @@
+Department,Collection,Folder,AIP_ID,Title,Version
+banana,ban-coll,aip-1,aip-001,title-1,1
+banana,ban-coll,aip-2,aip-002,title-2,1
+Brown,bma-coll,aip-3,bma-aip-001,bma-title-1,1

--- a/tests/check_metadata_csv/error_repeat_metadata.csv
+++ b/tests/check_metadata_csv/error_repeat_metadata.csv
@@ -1,0 +1,6 @@
+Department,Collection,Folder,AIP_ID,Title,Version
+test,test-coll,aip-1,aip-001,title-1,1
+test,test-coll,aip-2,aip-002,title-2,1
+test,test-coll,aip-3,aip-003,title-3,1
+test,test-coll,aip-2,aip-004,title-4,1
+test,test-coll,aip-3,aip-005,title-5,1

--- a/tests/test_check_metadata_csv.py
+++ b/tests/test_check_metadata_csv.py
@@ -1,112 +1,72 @@
 """Testing for the function test_check_metadata.csv, which takes data from a read CSV as input,
 tests if it meets UGA requirements, and returns either an empty list (no errors) or a list of errors.
 
-The CSVs used in testing are in the tests subfolder of the script repo.
 In production, the file must be named metadata.csv, but for testing a prefix is added with the test type."""
 
 import csv
 import os
-import shutil
 import unittest
 from aip_functions import check_metadata_csv
 
 
 def run_function(csv_name):
-    """
-    Reads the CSV, runs the function with the read data, and returns the function output.
-    """
-    with open(os.path.join("..", "metadata_csv", csv_name)) as open_metadata:
+    """Reads the CSV, runs the function with the read data, and returns the function output"""
+    aip_dir = os.path.join(os.getcwd(), 'tests', 'check_metadata_csv')
+    with open(os.path.join(aip_dir, csv_name)) as open_metadata:
         read_metadata = csv.reader(open_metadata)
-        output = check_metadata_csv(read_metadata)
+        output = check_metadata_csv(read_metadata, aip_dir)
     return output
 
 
 class TestCheckMetadataCSV(unittest.TestCase):
 
-    def setUp(self):
-        """
-        Makes folders to use as test data.
-        """
-        # Makes a folder for the AIPs directory and makes it the current directory.
-        os.mkdir("aips_directory")
-        os.chdir("aips_directory")
-
-        # Makes three folders to represent AIPs.
-        os.mkdir("aip-1")
-        os.mkdir("aip-2")
-        os.mkdir("aip-3")
-
-    def tearDown(self):
-        """
-        Deletes the files and folders used for testing, which are all in the AIPs directory.
-        Changes the current directory first to avoid a permissions error.
-        """
-        os.chdir("..")
-        shutil.rmtree("aips_directory")
-
     def test_correct(self):
-        """
-        Test for a metadata.csv with valid information 
-        and column case matches the README instructions exactly.
-        """
-        result = run_function("correct_same_case_metadata.csv")
+        """Test for a metadata.csv with the correct information (column case matches)"""
+        result = run_function('correct_same_case_metadata.csv')
         expected = []
-        self.assertEqual(result, expected, "Problem with test for correct_same_case_metadata.csv")
+        self.assertEqual(expected, result, "Problem with test for correct_same_case_metadata.csv")
 
     def test_correct_case_difference(self):
-        """
-        Test for a metadata.csv with valid information
-        and the column case doesn't match the README instructions. This is not an error.
-        """
-        result = run_function("correct_diff_case_metadata.csv")
+        """Test for a metadata.csv with the correct information (column case different)"""
+        result = run_function('correct_diff_case_metadata.csv')
         expected = []
-        self.assertEqual(result, expected, "Problem with test for correct_diff_case_metadata.csv")
+        self.assertEqual(expected, result, "Problem with test for correct_diff_case_metadata.csv")
 
     def test_error_columns(self):
-        """
-        Test for the column names in metadata.csv not matching the expected values.
-        """
-        result = run_function("error_column_order_metadata.csv")
-        expected = ["The columns in the metadata.csv do not match the required values or order.",
-                    "Required: Department, Collection, Folder, AIP_ID, Title, Version",
-                    "Current:  AIP_ID, Department, Collection, Folder, Title, Version",
-                    "Since the columns are not correct, did not check the column values."]
-        self.assertEqual(result, expected, "Problem with test for error, columns")
+        """Test for the column names in metadata.csv not matching the expected values"""
+        result = run_function('error_column_order_metadata.csv')
+        expected = ['The columns in the metadata.csv do not match the required values or order.',
+                    'Required: Department, Collection, Folder, AIP_ID, Title, Version',
+                    'Current:  AIP_ID, Department, Collection, Folder, Title, Version',
+                    'Since the columns are not correct, did not check the column values.']
+        self.assertEqual(expected, result, "Problem with test for error, columns")
 
     def test_error_group(self):
-        """
-        Test for departments in the metadata.csv which are not ARCHive groups (from the configuration file).
-        """
-        result = run_function("error_group_metadata.csv")
-        expected = ["Brown is not an ARCHive group.", "banana is not an ARCHive group."]
-        self.assertEqual(result, expected, "Problem with test for error, group")
+        """Test for departments in the metadata.csv which are not ARCHive groups (from the configuration file)"""
+        result = run_function('error_group_metadata.csv')
+        expected = ['Brown is not an ARCHive group.', 'banana is not an ARCHive group.']
+        self.assertEqual(expected, result, "Problem with test for error, group")
 
     def test_error_repeated_folders(self):
-        """
-        Test for AIPs that are in the metadata.csv more than once.
-        """
-        result = run_function("error_repeat_metadata.csv")
-        expected = ["aip-2 is in the metadata.csv folder column more than once.",
-                    "aip-3 is in the metadata.csv folder column more than once."]
-        self.assertEqual(result, expected, "Problem with test for error, repeated folders")
+        """Test for AIPs that are in the metadata.csv more than once"""
+        result = run_function('error_repeat_metadata.csv')
+        expected = ['aip-2 is in the metadata.csv folder column more than once.',
+                    'aip-3 is in the metadata.csv folder column more than once.']
+        self.assertEqual(expected, result, "Problem with test for error, repeated folders")
 
     def test_error_csv_only(self):
-        """
-        Test for AIP folders that are only in the metadata.csv and not in the AIPs directory.
-        """
-        result = run_function("error_csv_only_metadata.csv")
-        expected = ["aip-4 is in metadata.csv and missing from the AIPs directory.",
-                    "aip-5 is in metadata.csv and missing from the AIPs directory."]
-        self.assertEqual(result, expected, "Problem with test for error, CSV only")
+        """Test for AIP folders that are only in the metadata.csv and not in the AIPs directory"""
+        result = run_function('error_csv_only_metadata.csv')
+        expected = ['aip-4 is in metadata.csv and missing from the AIPs directory.',
+                    'aip-5 is in metadata.csv and missing from the AIPs directory.']
+        self.assertEqual(expected, result, "Problem with test for error, CSV only")
 
     def test_error_directory_only(self):
-        """
-        Test for AIP folders that are only in the AIPs directory and not the metadata.csv.
-        """
-        result = run_function("error_directory_only_metadata.csv")
-        expected = ["aip-1 is in the AIPs directory and missing from metadata.csv.",
-                    "aip-3 is in the AIPs directory and missing from metadata.csv."]
-        self.assertEqual(result, expected, "Problem with test for error, directory only")
+        """Test for AIP folders that are only in the AIPs directory and not the metadata.csv"""
+        result = run_function('error_directory_only_metadata.csv')
+        expected = ['aip-1 is in the AIPs directory and missing from metadata.csv.',
+                    'aip-3 is in the AIPs directory and missing from metadata.csv.']
+        self.assertEqual(expected, result, "Problem with test for error, directory only")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add aips_dir as a parameter for when the current working directory is no longer changed to the aips_dir. That was causing confusion about correct file paths while editing the script or making tests. Many functions will need to be updated this way.