### PR TITLE
AV make_bag()

### DIFF
--- a/aip_functions.py
+++ b/aip_functions.py
@@ -438,7 +438,7 @@ def make_bag(aip):
         bagit.make_bag(aip_path, checksums=["md5", "sha256"])
 
     # Renames the AIP folder to add _bag (common naming convention for the standard).
-    os.replace(aip.id, f"{aip.id}_bag")
+    os.replace(aip_path, os.path.join(aip.directory, f"{aip.id}_bag"))
 
 
 def make_cleaned_fits_xml(aip):

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -427,6 +427,10 @@ def make_bag(aip):
     Returns: none
     """
 
+    # Deletes temporary files. These can be re-generated during the AIP creation process.
+    aip_path = os.path.join(aip.directory, aip.id)
+    delete_temp(aip, aip_path, logging=False)
+
     # Bags the AIP.
     bagit.make_bag(aip.id, checksums=["md5", "sha256"])
 

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -431,8 +431,11 @@ def make_bag(aip):
     aip_path = os.path.join(aip.directory, aip.id)
     delete_temp(aip, aip_path, logging=False)
 
-    # Bags the AIP.
-    bagit.make_bag(aip.id, checksums=["md5", "sha256"])
+    # Bags the AIP. To save time, BMAC AV only generates md5 checksums.
+    if aip.type == "av" and aip.department == "bmac":
+        bagit.make_bag(aip_path, checksums=["md5"])
+    else:
+        bagit.make_bag(aip_path, checksums=["md5", "sha256"])
 
     # Renames the AIP folder to add _bag (common naming convention for the standard).
     os.replace(aip.id, f"{aip.id}_bag")

--- a/tests/make_bag/rabbitbox_0001_copy/.Placeholder for temp to delete.txt
+++ b/tests/make_bag/rabbitbox_0001_copy/.Placeholder for temp to delete.txt
@@ -1,0 +1,1 @@
+Should be deleted during bagging

--- a/tests/make_bag/rabbitbox_0001_copy/Placeholder for AIP content.txt
+++ b/tests/make_bag/rabbitbox_0001_copy/Placeholder for AIP content.txt
@@ -1,0 +1,2 @@
+Placeholder for the metadata and objects folder
+for a BMAC AIP

--- a/tests/make_bag/rbrl025_0001_media_copy/Placeholder for AIP content.txt
+++ b/tests/make_bag/rbrl025_0001_media_copy/Placeholder for AIP content.txt
@@ -1,0 +1,2 @@
+Placeholder for the metadata and objects folder
+for a Russel AV AIP

--- a/tests/make_bag/rbrl_025_er_000001_copy/Placeholder for AIP content.txt
+++ b/tests/make_bag/rbrl_025_er_000001_copy/Placeholder for AIP content.txt
@@ -1,0 +1,2 @@
+Placeholder for the metadata and objects folder
+for a Russel general AIP

--- a/tests/make_bag/test_001_01_copy/Placeholder for AIP content.txt
+++ b/tests/make_bag/test_001_01_copy/Placeholder for AIP content.txt
@@ -1,0 +1,2 @@
+Placeholder for the metadata and objects folder
+for a Russel general AIP

--- a/tests/make_bag/test_001_01_copy/Thumbs.db
+++ b/tests/make_bag/test_001_01_copy/Thumbs.db
@@ -1,0 +1,1 @@
+Placeholder for Thumbs.db

--- a/tests/test_make_bag.py
+++ b/tests/test_make_bag.py
@@ -1,73 +1,108 @@
 """Testing for the function make_bag, which takes an AIP class instance as input and makes it into a bag,
 with md5 and sha256 checksums. The bag folder is renamed with "_bag" suffix."""
 
+from datetime import datetime
 import os
 import shutil
 import unittest
 from aip_functions import AIP, make_bag
+from test_script import make_directory_list
 
 
 class TestMakeBag(unittest.TestCase):
 
-    def setUp(self):
-        """
-        Makes an AIP instance and corresponding folder to use for testing.
-        """
-        # Makes the AIP instance and a folder named with the AIP ID.
-        self.aip = AIP(os.getcwd(), "test", "coll-1", "aip-folder", "aip-id", "title", 1, True)
-        os.mkdir(self.aip.id)
-
-        # Makes the AIP metadata folder and metadata files.
-        # To save time, since they are not used for the test, the metadata files are text files and not real.
-        os.mkdir(os.path.join(self.aip.id, "metadata"))
-        with open(os.path.join(self.aip.id, "metadata", "file_fits.xml"), "w") as file:
-            file.write("Text")
-        with open(os.path.join(self.aip.id, "metadata", f"{self.aip.id}_preservation.xml"), "w") as file:
-            file.write("Text")
-
-        # Makes the AIP object folder and a test file.
-        os.mkdir(os.path.join(self.aip.id, "objects"))
-        with open(os.path.join(self.aip.id, "objects", "file.txt"), "w") as file:
-            file.write("Test")
-
     def tearDown(self):
-        """
-        If they are present, deletes the test AIP (if correctly renamed to add "_bag" or if it isn't),
-        the AIP log and the errors folder.
-        """
-        if os.path.exists(f"{self.aip.id}_bag"):
-            shutil.rmtree(f"{self.aip.id}_bag")
-        elif os.path.exists(self.aip.id):
-            shutil.rmtree(self.aip.id)
+        """If they are present, deletes the test AIPs if correctly renamed to add "_bag" or not"""
+        aips_dir = os.path.join(os.getcwd(), 'make_bag')
+        aips = ['rabbitbox_0001', 'rbrl_025_er_000001', 'rbrl025_0001_media', 'test_001_01']
+        for aip in aips:
+            if os.path.exists(os.path.join(aips_dir, aip)):
+                shutil.rmtree(os.path.join(aips_dir, aip))
+            elif os.path.exists(os.path.join(aips_dir, f'{aip}_bag')):
+                shutil.rmtree(os.path.join(aips_dir, f'{aip}_bag'))
 
-        log_path = os.path.join("..", "aip_log.csv")
-        if os.path.exists(log_path):
-            os.remove(log_path)
+    def test_av_bmac(self):
+        """Test for making a bag out of an AIP folder that is AV from BMAC"""
+        # Makes the test input and runs the function.
+        # A copy of the AIP is made since this test should move it to an error folder.
+        aips_dir = os.path.join(os.getcwd(), 'make_bag')
+        aip = AIP(aips_dir, 'bmac', 'mp4', 'rabbitbox', 'folder', 'av', 'rabbitbox_0001', 'title', 1, True)
+        shutil.copytree(os.path.join(aips_dir, f'{aip.id}_copy'), os.path.join(aips_dir, aip.id))
+        make_bag(aip)
 
-        errors_path = os.path.join("..", "errors")
-        if os.path.exists(errors_path):
-            shutil.rmtree(errors_path)
+        # Verifies the AIP is now a bag, based on the folder name and contents.
+        result = make_directory_list(os.path.join(aips_dir, f'{aip.id}_bag'))
+        date = datetime.today().strftime('%Y-%#m-%#d')
+        expected = [os.path.join(aips_dir, f'{aip.id}_bag', 'bag-info.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'bagit.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'data'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'data', 'Placeholder for AIP content.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'manifest-md5.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'tagmanifest-md5.txt')]
+        self.assertEqual(expected, result, "Problem with av_bmac")
 
-    def test_make_bag(self):
-        """
-        Test for making a bag out of an AIP folder.
-        Result for testing is the contents of the bag folder (the bag metadata files).
-        """
-        make_bag(self.aip)
+    def test_av_russell(self):
+        """Test for making a bag out of an AIP folder that is AV from Russell"""
+        # Makes the test input and runs the function.
+        # A copy of the AIP is made since this test should move it to an error folder.
+        aips_dir = os.path.join(os.getcwd(), 'make_bag')
+        aip = AIP(aips_dir, 'russell', 'mp4', 'rbrl025', 'folder', 'av', 'rbrl025_0001_media', 'title', 1, True)
+        shutil.copytree(os.path.join(aips_dir, f'{aip.id}_copy'), os.path.join(aips_dir, aip.id))
+        make_bag(aip)
 
-        # If the renamed bag folder is present, a directory print of the folder is the test result.
-        # Otherwise, default error language is the result.
-        if os.path.exists(f"{self.aip.id}_bag"):
-            result = []
-            for item in os.listdir(f"{self.aip.id}_bag"):
-                result.append(item)
-        else:
-            result = "AIP's bag folder not found"
+        # Verifies the AIP is now a bag, based on the folder name and contents.
+        result = make_directory_list(os.path.join(aips_dir, f'{aip.id}_bag'))
+        expected = [os.path.join(aips_dir, f'{aip.id}_bag', 'bag-info.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'bagit.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'data'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'data', 'Placeholder for AIP content.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'manifest-md5.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'manifest-sha256.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'tagmanifest-md5.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'tagmanifest-sha256.txt')]
+        self.assertEqual(expected, result, "Problem with av_russell")
 
-        expected = ["bag-info.txt", "bagit.txt", "data", "manifest-md5.txt", "manifest-sha256.txt",
-                    "tagmanifest-md5.txt", "tagmanifest-sha256.txt"]
+    def test_general(self):
+        """Test for making a bag out of an AIP folder that is the general type"""
+        # Makes the test input and runs the function.
+        # A copy of the AIP is made since this test should move it to an error folder.
+        aips_dir = os.path.join(os.getcwd(), 'make_bag')
+        aip = AIP(aips_dir, 'russell', None, 'rbrl_025', 'folder', 'general', 'rbrl_025_er_000001', 'title', 1, True)
+        shutil.copytree(os.path.join(aips_dir, f'{aip.id}_copy'), os.path.join(aips_dir, aip.id))
+        make_bag(aip)
 
-        self.assertEqual(result, expected, "Problem with make bag")
+        # Verifies the AIP is now a bag, based on the folder name and contents.
+        result = make_directory_list(os.path.join(aips_dir, f'{aip.id}_bag'))
+        expected = [os.path.join(aips_dir, f'{aip.id}_bag', 'bag-info.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'bagit.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'data'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'data', 'Placeholder for AIP content.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'manifest-md5.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'manifest-sha256.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'tagmanifest-md5.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'tagmanifest-sha256.txt')]
+        self.assertEqual(expected, result, "Problem with general")
+
+    def test_temp(self):
+        """Test for making a bag out of an AIP folder that has temp files that should be deleted"""
+        # Makes the test input and runs the function.
+        # A copy of the AIP is made since this test should move it to an error folder.
+        aips_dir = os.path.join(os.getcwd(), 'make_bag')
+        aip = AIP(aips_dir, 'test', None, 'test_001', 'folder', 'general', 'test_001_01', 'title', 1, True)
+        shutil.copytree(os.path.join(aips_dir, f'{aip.id}_copy'), os.path.join(aips_dir, aip.id))
+        make_bag(aip)
+
+        # Verifies the AIP is now a bag, based on the folder name and contents, with none of the temp files.
+        result = make_directory_list(os.path.join(aips_dir, f'{aip.id}_bag'))
+        expected = [os.path.join(aips_dir, f'{aip.id}_bag', 'bag-info.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'bagit.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'data'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'data', 'Placeholder for AIP content.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'manifest-md5.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'manifest-sha256.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'tagmanifest-md5.txt'),
+                    os.path.join(aips_dir, f'{aip.id}_bag', 'tagmanifest-sha256.txt')]
+        self.assertEqual(expected, result, "Problem with temp")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Delete temps without logging, only do MD5 if it is AV since SHA is slow, and use the full path when renaming the AIP folder