### PR TITLE
AV package()

### DIFF
--- a/aip_functions.py
+++ b/aip_functions.py
@@ -691,7 +691,8 @@ def package(aip, staging):
         subprocess.run(f'tar -C "{bag_path}" -cf "{tar_path}" .', shell=True)
 
     # Renames the file to include the size.
-    os.replace(f"{aip_bag}.tar", f"{aip_bag}.{bag_size}.tar")
+    tar_size_path = os.path.join(staging, "aips-ready-to-ingest", f"{aip_bag}.{bag_size}.tar")
+    os.replace(tar_path, tar_size_path)
 
     # Updates the size in the AIP object so it can be used by the manifest() function later.
     aip.size = bag_size

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -655,15 +655,21 @@ def package(aip, staging):
     # Gets the total size of the bag:
     # sum of the bag payload (data folder) from bag-info.txt and the size of the bag metadata files.
     # It saves time to use the bag payload instead of recalculating the size of a large data folder.
+    try:
+        bag_info = open(os.path.join(bag_path, "bag-info.txt"), "r")
+    except FileNotFoundError:
+        aip.log["Package"] = f"Could not tar. Bag not in expected location: {bag_path}"
+        aip.log["Complete"] = "Error during processing"
+        log(aip.log, aip.directory)
+        return
     bag_size = 0
-    bag_info = open(os.path.join(aip_bag, "bag-info.txt"), "r")
     for line in bag_info:
         if line.startswith("Payload-Oxum"):
             payload = line.split()[1]
             bag_size += float(payload)
-    for file in os.listdir(aip_bag):
+    for file in os.listdir(bag_path):
         if file.endswith(".txt"):
-            bag_size += os.path.getsize(os.path.join(aip_bag, file))
+            bag_size += os.path.getsize(os.path.join(bag_path, file))
     bag_info.close()
     bag_size = int(bag_size)
 

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -629,14 +629,15 @@ def organize_xml(aip, staging):
     os.remove(os.path.join(aip.directory, aip.id, "metadata", f"{aip.id}_cleaned-fits.xml"))
 
 
-def package(aip):
-    """Tar and zip (optional) the AIP, rename it to include the size, and save it to the aips-to-ingest folder
+def package(aip, staging):
+    """Tar and zip (optional) the AIP, rename it to include the size, and save it to the aips-ready-to-ingest folder
 
     AIPs may not be zipped if zipping is time-consuming and does not save much space. They must be tarred.
     The unzipped size is included so the preservation system can determine if there is room to unzip it during ingest.
 
     Parameters:
          aip : instance of the AIP class, used for directory, id, log, size, and to_zip
+         staging : path to the aip_staging folder from configuration.py
 
     Returns: none
     """
@@ -644,8 +645,9 @@ def package(aip):
     # Gets the operating system, since the tar and zip commands are different for Windows and Mac/Linux.
     operating_system = platform.system()
 
-    # Makes a variable for the AIP folder name, which is reused a lot.
+    # Makes variables for the AIP folder name and AIP full path.
     aip_bag = f"{aip.id}_bag"
+    bag_path = os.path.join(aip.directory, aip_bag)
 
     # Gets the total size of the bag:
     # sum of the bag payload (data folder) from bag-info.txt and the size of the bag metadata files.

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -688,7 +688,7 @@ def package(aip, staging):
             log(aip.log, aip.directory)
             return
     else:
-        subprocess.run(f'tar -cf "{aip_bag}.tar" "{aip_bag}"', shell=True)
+        subprocess.run(f'tar -C "{bag_path}" -cf "{tar_path}" .', shell=True)
 
     # Renames the file to include the size.
     os.replace(f"{aip_bag}.tar", f"{aip_bag}.{bag_size}.tar")

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -710,7 +710,7 @@ def package(aip, staging):
         # Deletes the tar version. Just want the tarred and zipped version.
         # For Mac/Linux, the bzip2 command overwrites the tar file so this step is unnecessary.
         if operating_system == "Windows":
-            os.remove(f"{aip_bag}.{bag_size}.tar")
+            os.remove(tar_size_path)
 
         # Moves the tarred and zipped version to the aips-to-ingest folder.
         path = os.path.join("..", "aips-to-ingest", f"{aip_bag}.{bag_size}.tar.bz2")

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -649,6 +649,9 @@ def package(aip, staging):
     aip_bag = f"{aip.id}_bag"
     bag_path = os.path.join(aip.directory, aip_bag)
 
+    # Deletes temporary files. These can be re-generated during the AIP creation process.
+    delete_temp(aip, bag_path, logging=False)
+
     # Gets the total size of the bag:
     # sum of the bag payload (data folder) from bag-info.txt and the size of the bag metadata files.
     # It saves time to use the bag payload instead of recalculating the size of a large data folder.

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -712,15 +712,6 @@ def package(aip, staging):
         if operating_system == "Windows":
             os.remove(tar_size_path)
 
-        # Moves the tarred and zipped version to the aips-to-ingest folder.
-        path = os.path.join("..", "aips-to-ingest", f"{aip_bag}.{bag_size}.tar.bz2")
-        os.replace(f"{aip_bag}.{bag_size}.tar.bz2", path)
-
-    # If not zipping, moves the tarred version to the aips-to-ingest folder.
-    else:
-        path = os.path.join("..", "aips-to-ingest", f"{aip_bag}.{bag_size}.tar")
-        os.replace(f"{aip_bag}.{bag_size}.tar", path)
-
     # Updates the log with success.
     aip.log["Package"] = "Successfully made package"
 

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -674,10 +674,10 @@ def package(aip, staging):
     bag_size = int(bag_size)
 
     # Tars the file, using the command appropriate for the operating system.
+    tar_path = os.path.join(staging, 'aips-ready-to-ingest', f"{aip_bag}.tar")
     if operating_system == "Windows":
         # Does not print the progress to the terminal (stdout), which is a lot of text. [subprocess.DEVNULL]
-        bag_path = os.path.join(aip.directory, aip_bag)
-        tar_output = subprocess.run(f'"C:/Program Files/7-Zip/7z.exe" -ttar a "{aip_bag}.tar" "{bag_path}"',
+        tar_output = subprocess.run(f'"C:/Program Files/7-Zip/7z.exe" -ttar a "{tar_path}" "{bag_path}"',
                                     stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, shell=True)
         # If there is an error, saves the error to the log and does not complete the rest of the function for this AIP.
         # Cannot move it to an error folder because getting a permissions error.
@@ -685,7 +685,7 @@ def package(aip, staging):
             error_msg = tar_output.stderr.decode("utf-8")
             aip.log["Package"] = f"Could not tar. 7zip error: {error_msg}"
             aip.log["Complete"] = "Error during processing"
-            log(aip.log)
+            log(aip.log, aip.directory)
             return
     else:
         subprocess.run(f'tar -cf "{aip_bag}.tar" "{aip_bag}"', shell=True)

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -700,13 +700,12 @@ def package(aip, staging):
     # If the AIP should be zipped (if the value of to_zip is true),
     # Zips (bz2) the tar file, using the command appropriate for the operating system.
     if aip.to_zip is True:
-        aip_tar = f"{aip_bag}.{bag_size}.tar"
         if operating_system == "Windows":
             # Does not print the progress to the terminal (stdout), which is a lot of text.
-            subprocess.run(f'"C:/Program Files/7-Zip/7z.exe" -tbzip2 a -aoa "{aip_tar}.bz2" "{aip_tar}"',
+            subprocess.run(f'"C:/Program Files/7-Zip/7z.exe" -tbzip2 a -aoa "{tar_size_path}.bz2" "{tar_size_path}"',
                            stdout=subprocess.DEVNULL, shell=True)
         else:
-            subprocess.run(f'bzip2 "{aip_tar}"', shell=True)
+            subprocess.run(f'bzip2 "{tar_size_path}"', shell=True)
 
         # Deletes the tar version. Just want the tarred and zipped version.
         # For Mac/Linux, the bzip2 command overwrites the tar file so this step is unnecessary.

--- a/tests/package/test-aip-1_bag/bag-info.txt
+++ b/tests/package/test-aip-1_bag/bag-info.txt
@@ -1,0 +1,3 @@
+Bag-Software-Agent: bagit.py v1.8.1 <https://github.com/LibraryOfCongress/bagit-python>
+Bagging-Date: 2025-07-14
+Payload-Oxum: 184.2

--- a/tests/package/test-aip-1_bag/bagit.txt
+++ b/tests/package/test-aip-1_bag/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/tests/package/test-aip-1_bag/data/metadata/Placeholder for metadata.txt
+++ b/tests/package/test-aip-1_bag/data/metadata/Placeholder for metadata.txt
@@ -1,0 +1,1 @@
+Stand in for metadata, as the expected files are needed for this test.

--- a/tests/package/test-aip-1_bag/data/objects/Placeholder for content.txt
+++ b/tests/package/test-aip-1_bag/data/objects/Placeholder for content.txt
@@ -1,0 +1,2 @@
+Stand in for the files and folders that would be part of the AIP,
+since actual files aren't needed for this test.

--- a/tests/package/test-aip-1_bag/manifest-md5.txt
+++ b/tests/package/test-aip-1_bag/manifest-md5.txt
@@ -1,0 +1,2 @@
+e00811241e9c63dc005f6ae100e671b8  data/metadata/Placeholder for metadata.txt
+3aa2a2874b5507acb5aca675d422aecf  data/objects/Placeholder for content.txt

--- a/tests/package/test-aip-1_bag/tagmanifest-md5.txt
+++ b/tests/package/test-aip-1_bag/tagmanifest-md5.txt
@@ -1,0 +1,3 @@
+1dd009e9e7a1dda2571a1189a046576c bag-info.txt
+9e5ad981e0d29adc278f6a294b8c2aca bagit.txt
+e9f6ff7ea971f2ef778c82fc0e6dc8e4 manifest-md5.txt

--- a/tests/package/test-aip-2_bag_copy/bag-info.txt
+++ b/tests/package/test-aip-2_bag_copy/bag-info.txt
@@ -1,0 +1,3 @@
+Bag-Software-Agent: bagit.py v1.8.1 <https://github.com/LibraryOfCongress/bagit-python>
+Bagging-Date: 2025-07-14
+Payload-Oxum: 184.2

--- a/tests/package/test-aip-2_bag_copy/bagit.txt
+++ b/tests/package/test-aip-2_bag_copy/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/tests/package/test-aip-2_bag_copy/data/metadata/.Placeholder for metadata.txt
+++ b/tests/package/test-aip-2_bag_copy/data/metadata/.Placeholder for metadata.txt
@@ -1,0 +1,1 @@
+Stand in for metadata, as the expected files are needed for this test.

--- a/tests/package/test-aip-2_bag_copy/data/metadata/Placeholder for metadata.txt
+++ b/tests/package/test-aip-2_bag_copy/data/metadata/Placeholder for metadata.txt
@@ -1,0 +1,1 @@
+Stand in for metadata, as the expected files are needed for this test.

--- a/tests/package/test-aip-2_bag_copy/data/objects/Placeholder for content.txt
+++ b/tests/package/test-aip-2_bag_copy/data/objects/Placeholder for content.txt
@@ -1,0 +1,2 @@
+Stand in for the files and folders that would be part of the AIP,
+since actual files aren't needed for this test.

--- a/tests/package/test-aip-2_bag_copy/data/objects/Thumbs.db
+++ b/tests/package/test-aip-2_bag_copy/data/objects/Thumbs.db
@@ -1,0 +1,1 @@
+Placeholder for Thumbs.db

--- a/tests/package/test-aip-2_bag_copy/manifest-md5.txt
+++ b/tests/package/test-aip-2_bag_copy/manifest-md5.txt
@@ -1,0 +1,2 @@
+e00811241e9c63dc005f6ae100e671b8  data/metadata/Placeholder for metadata.txt
+3aa2a2874b5507acb5aca675d422aecf  data/objects/Placeholder for content.txt

--- a/tests/package/test-aip-2_bag_copy/tagmanifest-md5.txt
+++ b/tests/package/test-aip-2_bag_copy/tagmanifest-md5.txt
@@ -1,0 +1,3 @@
+1dd009e9e7a1dda2571a1189a046576c bag-info.txt
+9e5ad981e0d29adc278f6a294b8c2aca bagit.txt
+e9f6ff7ea971f2ef778c82fc0e6dc8e4 manifest-md5.txt

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,107 +1,185 @@
 """Testing for the function package, which tars and (optionally) zips the bag for the AIP,
-renames it to add the unzipped size, and saves to the aips-to-ingest folder.
+renames it to add the unzipped size, and saves to the aips-ready-to-ingest folder.
 
-The function currently tests for the operating system and uses different commands.
-This test is just for Windows. The function will be updated to use Python instead of OS-specific tools."""
+NOTE: The packaged AIPs have a different size depending on if the tests were run on Windows or Mac,
+so the expected results and the tearDown look for either possible size.
+"""
 
 import os
 import shutil
+import tarfile
 import unittest
-from aip_functions import AIP, make_output_directories, make_bag, package
+from aip_functions import AIP, log, package
+from test_script import make_aip_log_list
 
 
 class TestPackage(unittest.TestCase):
 
-    def setUp(self):
-        """
-        Makes an AIP instance, corresponding bagged folder with files, and the script output folders.
-        The folder does not have the required metadata, since that isn"t necessary for this test.
-        """
-        self.aip = AIP(os.getcwd(), "test", "test-coll", "test-aip-id", "test-aip-id", "title", 1, to_zip=True)
-        os.mkdir(self.aip.folder_name)
-        for file_name in ("file1.txt", "file2.txt", "file3.txt"):
-            with open(os.path.join(self.aip.folder_name, file_name), "w") as file:
-                file.write("Test Test Test Test" * 100)
-        make_bag(self.aip)
-        make_output_directories()
-
     def tearDown(self):
-        """
-        Deletes the bagged AIP, script output folders, and AIP log (if created).
-        """
-        shutil.rmtree(f"{self.aip.id}_bag")
-        shutil.rmtree(os.path.join("..", "aips-to-ingest"))
-        os.rmdir(os.path.join("..", "fits-xml"))
-        os.rmdir(os.path.join("..", "preservation-xml"))
+        """Deletes the AIP log, copy of the test aip for deletions, and packaged AIP if created"""
+        log_path = os.path.join(os.getcwd(), 'package', 'aip_log.csv')
+        if os.path.exists(log_path):
+            os.remove(log_path)
 
-        if os.path.exists(os.path.join("..", "aip_log.csv")):
-            os.remove(os.path.join("..", "aip_log.csv"))
+        aip_path = os.path.join(os.getcwd(), 'package', 'test-aip-2_bag')
+        if os.path.exists(aip_path):
+            shutil.rmtree(aip_path)
+
+        aips_ready_path = os.path.join(os.getcwd(), 'staging', 'aips-ready-to-ingest')
+        for pkg in ['test-aip-1_bag.663.tar', 'test-aip-1_bag.663.tar.bz2',
+                    'test-aip-1_bag.673.tar', 'test-aip-1_bag.673.tar.bz2',
+                    'test-aip-2_bag.663.tar', 'test-aip-2_bag.673.tar']:
+            if os.path.exists(os.path.join(aips_ready_path, pkg)):
+                os.remove(os.path.join(aips_ready_path, pkg))
 
     def test_tar_zip(self):
-        """
-        Test for an AIP that should be tarred and zipped.
-        """
-        # Runs the function being tested.
-        package(self.aip)
+        """Test for an AIP that should be tarred and zipped."""
+        # Makes the test input and runs the function.
+        aips_dir = os.path.join(os.getcwd(), 'package')
+        aip_staging = os.path.join(os.getcwd(), 'staging')
+        aip = AIP(aips_dir, 'test', None, 'collection', 'folder', 'general', 'test-aip-1', 'title', 1, True)
+        package(aip, aip_staging)
 
         # Test that the tar.bz2 file is in the aips-to-ingest folder.
-        result_ingest = os.path.exists(os.path.join("..", "aips-to-ingest", "test-aip-id_bag.6791.tar.bz2"))
-        self.assertEqual(result_ingest, True, "Problem with tar and zip, aips-to-ingest")
-        
-        # Test that the tar.bz2 file and tar file are not in the AIPs directory.
-        # The tar.bz2 file should have been moved to aips-to-ingest
-        # and the tar file is temporary and should have been deleted.
-        result_aip_dir = (os.path.exists("test-aip-id_bag.6791.tar"), os.path.exists("test-aip-id_bag.6791.tar.bz2"))
-        expected_aip_dir = (False, False)
-        self.assertEqual(result_aip_dir, expected_aip_dir, "Problem with tar and zip, AIPs directory")
+        result = (os.path.exists(os.path.join(aip_staging, 'aips-ready-to-ingest', 'test-aip-1_bag.663.tar.bz2')) or
+                  os.path.exists(os.path.join(aip_staging, 'aips-ready-to-ingest', 'test-aip-1_bag.673.tar.bz2')))
+        self.assertEqual(result, True, "Problem with tar_zip, aips-ready-to-ingest")
 
-        # Test for the AIP log.
-        result_log = self.aip.log["Package"]
-        expected_log = "Successfully made package"
-        self.assertEqual(result_log, expected_log, "Problem with tar/zip, log")
+        # Test that the AIP size is updated.
+        result = aip.size
+        expected = [663, 673]
+        self.assertIn(result, expected, "Problem with tar_zip, AIP size")
+
+        # Test that the AIP log is updated.
+        result = aip.log['Package']
+        expected = 'Successfully made package'
+        self.assertEqual(expected, result, "Problem with tar_zip, AIP log")
 
     def test_tar(self):
-        """
-        Test for an AIP that should be tarred and not zipped.
-        Result for testing is if the tarred file is in the aips-to-ingest folder, plus the AIP log.
-        """
-        # Updates the default to_zip value to not zip and runs the function being tested.
-        self.aip.to_zip = False
-        package(self.aip)
+        """Test for an AIP that should be tarred but not zipped"""
+        # Makes the test input and runs the function.
+        aips_dir = os.path.join(os.getcwd(), 'package')
+        aip_staging = os.path.join(os.getcwd(), 'staging')
+        aip = AIP(aips_dir, 'test', None, 'collection', 'folder', 'general', 'test-aip-1', 'title', 1, False)
+        package(aip, aip_staging)
 
         # Test that the tar file is in the aips-to-ingest folder.
-        result_ingest = os.path.exists(os.path.join("..", "aips-to-ingest", "test-aip-id_bag.6791.tar"))
-        self.assertEqual(result_ingest, True, "Problem with tar, aips-to-ingest")
+        result = (os.path.exists(os.path.join(aip_staging, 'aips-ready-to-ingest', 'test-aip-1_bag.663.tar')) or
+                  os.path.exists(os.path.join(aip_staging, 'aips-ready-to-ingest', 'test-aip-1_bag.673.tar')))
+        self.assertEqual(result, True, "Problem with tar, aips-ready-to-ingest")
 
-        # Test that the tar file is not in the AIPs directory. It should have been moved to aips-to-ingest.
-        result_aip_dir = os.path.exists("test-aip=id_bag.6791.tar")
-        self.assertEqual(result_aip_dir, False, "Problem with tar, AIPs directory")
+        # Test that the tar file contains the expected file paths.
+        # Catches errors in how the tar is constructed, like if it contains unnecessary folders.
+        try:
+            with tarfile.open(os.path.join(aip_staging, 'aips-ready-to-ingest', 'test-aip-1_bag.663.tar')) as tar:
+                result = tar.getnames()
+        except FileNotFoundError:
+            with tarfile.open(os.path.join(aip_staging, 'aips-ready-to-ingest', 'test-aip-1_bag.673.tar')) as tar:
+                result = tar.getnames()
+        result.sort()
+        # Windows includes bag name in path and Mac has "." instead.
+        # Mac also has a copy of every file and folder with "._" prefix, which seems to be from the tar command.
+        # The bag is still valid and does now show any of these in the manifest.
+        expected = [['.', './._bag-info.txt', './._bagit.txt', './._data', './._manifest-md5.txt',
+                     './._tagmanifest-md5.txt', './bag-info.txt', './bagit.txt', './data', './data/._metadata',
+                     './data/._objects', './data/metadata', './data/metadata/._Placeholder for metadata.txt',
+                     './data/metadata/Placeholder for metadata.txt', './data/objects',
+                     './data/objects/._Placeholder for content.txt', './data/objects/Placeholder for content.txt',
+                     './manifest-md5.txt', './tagmanifest-md5.txt', '._.'],
+                    ['test-aip-1_bag', 'test-aip-1_bag/bag-info.txt', 'test-aip-1_bag/bagit.txt', 'test-aip-1_bag/data',
+                     'test-aip-1_bag/data/metadata', 'test-aip-1_bag/data/metadata/Placeholder for metadata.txt',
+                     'test-aip-1_bag/data/objects', 'test-aip-1_bag/data/objects/Placeholder for content.txt',
+                     'test-aip-1_bag/manifest-md5.txt', 'test-aip-1_bag/tagmanifest-md5.txt']]
+        self.assertIn(result, expected, "Problem with tar, tar contents")
+
+        # Test that the AIP size is updated.
+        result = aip.size
+        expected = [663, 673]
+        self.assertIn(result, expected, "Problem with tar, AIP size")
+
+        # Test that the AIP log is updated.
+        result = aip.log['Package']
+        expected = 'Successfully made package'
+        self.assertEqual(expected, result, "Problem with tar, AIP log")
+
+    def test_temp(self):
+        """Test for an AIP that had temp files created after bagging that should be deleted"""
+        # Makes the test input and runs the function.
+        aips_dir = os.path.join(os.getcwd(), 'package')
+        aip_staging = os.path.join(os.getcwd(), 'staging')
+        aip = AIP(aips_dir, 'test', None, 'collection', 'folder', 'general', 'test-aip-2', 'title', 1, False)
+        aip.log['Deletions'] = 'Deletions note (for testing)'
+        shutil.copytree(os.path.join(aips_dir, f'{aip.id}_bag_copy'), os.path.join(aips_dir, f'{aip.id}_bag'))
+        package(aip, aip_staging)
+
+        # Test that the tar file is in the aips-to-ingest folder.
+        result = (os.path.exists(os.path.join(aip_staging, 'aips-ready-to-ingest', 'test-aip-2_bag.663.tar')) or
+                  os.path.exists(os.path.join(aip_staging, 'aips-ready-to-ingest', 'test-aip-2_bag.673.tar')))
+        self.assertEqual(result, True, "Problem with temp, aips-ready-to-ingest")
+
+        # Test that the tar file contains the expected file paths.
+        # Catches errors in how the tar is constructed, like if it contains unnecessary folders.
+        try:
+            with tarfile.open(os.path.join(aip_staging, 'aips-ready-to-ingest', 'test-aip-2_bag.663.tar')) as tar:
+                result = tar.getnames()
+        except FileNotFoundError:
+            with tarfile.open(os.path.join(aip_staging, 'aips-ready-to-ingest', 'test-aip-2_bag.673.tar')) as tar:
+                result = tar.getnames()
+        result.sort()
+        # Windows includes bag name in path and Mac has "." instead.
+        # Mac also has a copy of every file and folder with "._" prefix, which seems to be from the tar command.
+        # The bag is still valid and does now show any of these in the manifest.
+        expected = [['.', './._bag-info.txt', './._bagit.txt', './._data', './._manifest-md5.txt',
+                     './._tagmanifest-md5.txt', './bag-info.txt', './bagit.txt', './data', './data/._metadata',
+                     './data/._objects', './data/metadata', './data/metadata/._Placeholder for metadata.txt',
+                     './data/metadata/Placeholder for metadata.txt', './data/objects',
+                     './data/objects/._Placeholder for content.txt', './data/objects/Placeholder for content.txt',
+                     './manifest-md5.txt', './tagmanifest-md5.txt', '._.'],
+                    ['test-aip-2_bag', 'test-aip-2_bag/bag-info.txt', 'test-aip-2_bag/bagit.txt', 'test-aip-2_bag/data',
+                     'test-aip-2_bag/data/metadata', 'test-aip-2_bag/data/metadata/Placeholder for metadata.txt',
+                     'test-aip-2_bag/data/objects', 'test-aip-2_bag/data/objects/Placeholder for content.txt',
+                     'test-aip-2_bag/manifest-md5.txt', 'test-aip-2_bag/tagmanifest-md5.txt']]
+        self.assertIn(result, expected, "Problem with temp, tar contents")
+
+        # Test that the AIP log size is updated.
+        result = aip.size
+        expected = [663, 673]
+        self.assertIn(result, expected, "Problem with temp, AIP size")
+
+        # Test that the AIP log deletion was not updated.
+        result = aip.log['Deletions']
+        expected = 'Deletions note (for testing)'
+        self.assertEqual(expected, result, "Problem with temp, AIP log - Deletions")
+
+        # Test that the AIP log package is updated.
+        result = aip.log['Package']
+        expected = 'Successfully made package'
+        self.assertEqual(expected, result, "Problem with temp, AIP log - Package")
+
+    def test_error(self):
+        """Test for when the bag folder to be packaged is missing"""
+        # Makes the test input and runs the function.
+        # The AIP log is updated as if previous steps have run correctly.
+        aips_dir = os.path.join(os.getcwd(), 'package')
+        aip_staging = os.path.join(os.getcwd(), 'staging')
+        aip = AIP(aips_dir, 'test', None, 'collection', 'folder', 'general', 'test-missing-1', 'title', 1, False)
+        aip.log = {'Started': '2025-08-14 10:55:01.000000', 'AIP': 'test-missing-1', 'Deletions': 'No files deleted',
+                   'ObjectsError': 'Success', 'MetadataError': 'Success', 'FITSTool': 'None', 'FITSError': 'Success',
+                   'PresXML': 'Success', 'PresValid': 'Valid', 'BagValid': 'Valid', 'Package': 'n/a',
+                   'Manifest': 'n/a', 'Complete': 'n/a'}
+        log('header', aips_dir)
+        package(aip, aip_staging)
 
         # Test for the AIP log.
-        result_log = self.aip.log["Package"]
-        expected_log = "Successfully made package"
-        self.assertEqual(result_log, expected_log, "Problem with tar, log")
-
-    def test_tar_error(self):
-        """
-        Test error handling if 7zip is not able to tar the file.
-        """
-        # Updates the default directory to a directory that does not exist, to cause the error,
-        # and runs the function being tested.
-        self.aip.directory = "DoesNotExist"
-        package(self.aip)
-
-        # Test for the AIP log, Package.
-        result_package = self.aip.log["Package"]
-        expected_package = "Could not tar. 7zip error: \r\n" \
-                           "WARNING: The system cannot find the file specified.\r\n" \
-                           "DoesNotExist\r\n\r\n"
-        self.assertEqual(result_package, expected_package, "Problem with tar error, log: Package")
-
-        # Test for the AIP log, Complete.
-        result_complete = self.aip.log["Complete"]
-        expected_complete = "Error during processing"
-        self.assertEqual(result_complete, expected_complete, "Problem with tar error, log: complete")
+        result = make_aip_log_list(os.path.join(os.getcwd(), 'package', 'aip_log.csv'))
+        expected = [['Time Started', 'AIP ID', 'Files Deleted', 'Objects Folder', 'Metadata Folder',
+                     'FITS Tool Errors', 'FITS Combination Errors', 'Preservation.xml Made', 'Preservation.xml Valid',
+                     'Bag Valid', 'Package Errors', 'Manifest Errors', 'Processing Complete'],
+                    ['2025-08-14', 'test-missing-1', 'No files deleted', 'Success', 'Success', 'BLANK',
+                     'Success', 'Success', 'Valid', 'Valid',
+                     f'Could not tar. Bag not in expected location: {os.path.join(aips_dir, "test-missing-1_bag")}',
+                     'BLANK', 'Error during processing']]
+        self.assertEqual(expected, result, "Problem with error")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Full paths for everything, update Mac tar command, only delete tar in Windows because Mac does automatically when making bz2 from tar, and don't need to move the tar/zip because it is made in the correct place.