### PR TITLE
Issue#102 to zip options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ Add one <dc:rights> element per rights statement with the URI of the right from 
 
 ### Script Arguments
 
-To run the script via the command line: python /path/general_aip.py aips_directory aip_type to_zip [workflow]
+To run the script via the command line: python /path/general_aip.py aips_directory aip_type zip_method [workflow]
 
 * aips_directory (required): folder that contains the folders to be made into AIPs
 * aip_type (required): either av, general, or web
-* to_zip (required): either no-zip (tar only) or zip (tar and bz2)
+* zip_method (required): tar or tar-bz2
 * workflow (optional): one of the AV workflows
 
 ### Testing

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -62,7 +62,7 @@ def check_arguments(arguments):
 
     # Checks if arguments were given, besides the default of script name.
     if len(arguments) == 1:
-        errors_list.append('Required arguments are missing: aips_directory, aip_type, and to_zip.')
+        errors_list.append('Required arguments are missing: aips_directory, aip_type, and zip_method.')
 
     # Checks if the first required argument (aips_directory) is present and a valid path.
     if len(arguments) > 1:
@@ -78,14 +78,14 @@ def check_arguments(arguments):
         else:
             errors_list.append(f'Provided aip_type "{arguments[2]}" is not an expected value (av, general, web).')
 
-    # Checks if the third required argument (to_zip) is present, and if so, if it is the expected value.
+    # Checks if the third required argument (zip_method) is present, and if so, if it is the expected value.
     if len(arguments) > 3:
         if arguments[3] == "no-zip":
             to_zip = False
         elif arguments[3] == "zip":
             to_zip = True
         else:
-            errors_list.append(f'Provided to_zip "{arguments[3]}" is not an expected value (no-zip, zip).')
+            errors_list.append(f'Provided zip_method "{arguments[3]}" is not an expected value (no-zip, zip).')
 
     # Checks if the optional argument (workflow) is present, and if so, if it is the expected value.
     if len(arguments) > 4:

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -80,12 +80,12 @@ def check_arguments(arguments):
 
     # Checks if the third required argument (zip_method) is present, and if so, if it is the expected value.
     if len(arguments) > 3:
-        if arguments[3] == "no-zip":
+        if arguments[3] == "tar":
             to_zip = False
-        elif arguments[3] == "zip":
+        elif arguments[3] == "tar-bz2":
             to_zip = True
         else:
-            errors_list.append(f'Provided zip_method "{arguments[3]}" is not an expected value (no-zip, zip).')
+            errors_list.append(f'Provided zip_method "{arguments[3]}" is not an expected value (tar or tar-bz2).')
 
     # Checks if the optional argument (workflow) is present, and if so, if it is the expected value.
     if len(arguments) > 4:

--- a/general_aip.py
+++ b/general_aip.py
@@ -7,7 +7,7 @@ Hargrett, MAGIL and Russell web IDs, and Emory disk image IDs.
 Parameters:
     aips_directory : required,  folder that contains the folders to be made into AIPs
     aip_type : required, either av, general, or web
-    to_zip : required, either no-zip (tar only) or zip (tar and bz2)
+    zip_method : required, either tar or tar-bz2
     workflow : optional, one of the AV workflows
 
 Returns:
@@ -124,7 +124,7 @@ for aip_row in read_metadata:
         a.make_bag(aip)
         a.validate_bag(aip, configuration.AIP_STAGING)
 
-    # Tars the AIP and also zips (bz2) the AIP if ZIP (optional script argument) is True.
+    # Tars the AIP and may also zip (bz2) depending on the script argument zip_method.
     if f'{aip.id}_bag' in os.listdir(AIPS_DIRECTORY):
         a.package(aip, configuration.AIP_STAGING)
 

--- a/tests/test_check_arguments.py
+++ b/tests/test_check_arguments.py
@@ -15,21 +15,21 @@ class TestCheckArguments(unittest.TestCase):
     def test_correct(self):
         """Test for when all required arguments are correct and the metadata.csv is present"""
         aips_dir = os.path.join(os.getcwd(), 'check_arguments', 'aips_dir')
-        result = check_arguments(['general-aip.py', aips_dir, 'general', 'zip'])
+        result = check_arguments(['general-aip.py', aips_dir, 'general', 'tar-bz2'])
         expected = (aips_dir, 'general', True, None, os.path.join(aips_dir, 'metadata.csv'), [])
         self.assertEqual(expected, result, "Problem with test for correct")
 
     def test_correct_optional(self):
         """Test for when all required arguments and optional argument are correct and the metadata.csv is present"""
         aips_dir = os.path.join(os.getcwd(), 'check_arguments', 'aips_dir')
-        result = check_arguments(['general-aip.py', aips_dir, 'av', 'no-zip', 'dpx'])
+        result = check_arguments(['general-aip.py', aips_dir, 'av', 'tar', 'dpx'])
         expected = (aips_dir, 'av', False, 'dpx', os.path.join(aips_dir, 'metadata.csv'), [])
         self.assertEqual(expected, result, "Problem with test for required argument only, correct")
 
     def test_metadata_missing(self):
         """Test for when the arguments are correct but the metadata.csv is not in the expected location"""
         aips_dir = os.path.join(os.getcwd(), 'check_arguments', 'no_metadata_csv')
-        result = check_arguments(['general-aip.py', aips_dir, 'web', 'zip'])
+        result = check_arguments(['general-aip.py', aips_dir, 'web', 'tar-bz2'])
         errors = ['Missing the required file metadata.csv in the AIPs directory.']
         expected = (aips_dir, 'web', True, None, None, errors)
         self.assertEqual(expected, result, "Problem with test for metadata_missing")
@@ -37,14 +37,14 @@ class TestCheckArguments(unittest.TestCase):
     def test_no_argument(self):
         """Test for when the user supplies no arguments. There is still one value in sys.argv, the script name"""
         result = check_arguments(['general-aip.py'])
-        errors = ['Required arguments are missing: aips_directory, aip_type, and to_zip.',
+        errors = ['Required arguments are missing: aips_directory, aip_type, and zip_method.',
                   'Cannot check for the metadata.csv because the AIPs directory has an error.']
         expected = (None, None, None, None, None, errors)
         self.assertEqual(expected, result, "Problem with test for no argument provided")
 
     def test_first_error(self):
         """Test for when the first argument (aips_directory) is not a valid path"""
-        result = check_arguments(['general-aip.py', 'aips-dir-path-error', 'av', 'zip', 'mkv'])
+        result = check_arguments(['general-aip.py', 'aips-dir-path-error', 'av', 'tar-bz2', 'mkv'])
         errors = ['Provided aips_directory "aips-dir-path-error" is not a valid directory.',
                   'Cannot check for the metadata.csv because the AIPs directory has an error.']
         expected = (None, 'av', True, 'mkv', None, errors)
@@ -53,23 +53,23 @@ class TestCheckArguments(unittest.TestCase):
     def test_second_error(self):
         """Test for when the second argument (aip_type) is not one of the expected values"""
         aips_dir = os.path.join(os.getcwd(), 'check_arguments', 'aips_dir')
-        result = check_arguments(['general-aip.py', aips_dir, 'type-error', 'no-zip', 'mov'])
+        result = check_arguments(['general-aip.py', aips_dir, 'type-error', 'tar', 'mov'])
         errors = ['Provided aip_type "type-error" is not an expected value (av, general, web).']
         expected = (aips_dir, None, False, 'mov', os.path.join(aips_dir, 'metadata.csv'), errors)
         self.assertEqual(expected, result, "Problem with test for second argument error")
 
     def test_third_error(self):
-        """Test for when the third argument (to_zip) is not one of the expected values"""
+        """Test for when the third argument (zip_method) is not one of the expected values"""
         aips_dir = os.path.join(os.getcwd(), 'check_arguments', 'aips_dir')
         result = check_arguments(['general-aip.py', aips_dir, 'av', 'zip-error', 'mp4'])
-        errors = [f'Provided to_zip "zip-error" is not an expected value (no-zip, zip).']
+        errors = [f'Provided zip_method "zip-error" is not an expected value (tar or tar-bz2).']
         expected = (aips_dir, 'av', None, 'mp4', os.path.join(aips_dir, 'metadata.csv'), errors)
         self.assertEqual(expected, result, "Problem with test for third argument error")
 
     def test_fourth_error(self):
         """Test for when the fourth argument (workflow) is not one of the expected values"""
         aips_dir = os.path.join(os.getcwd(), 'check_arguments', 'aips_dir')
-        result = check_arguments(['general-aip.py', aips_dir, 'general', 'zip', 'wf-error'])
+        result = check_arguments(['general-aip.py', aips_dir, 'general', 'tar-bz2', 'wf-error'])
         errors = ['Provided workflow "wf-error" is not an expected value (dpx, mkv, mkv-filmscan, mov, mp4, mxf, wav)']
         expected = (aips_dir, 'general', True, None, os.path.join(aips_dir, 'metadata.csv'), errors)
         self.assertEqual(expected, result, "Problem with test for fourth argument error")
@@ -79,7 +79,7 @@ class TestCheckArguments(unittest.TestCase):
         result = check_arguments(['general-aip.py', 'path-error', 'type-error', 'zip-error', 'wf-error'])
         errors = ['Provided aips_directory "path-error" is not a valid directory.',
                   'Provided aip_type "type-error" is not an expected value (av, general, web).',
-                  'Provided to_zip "zip-error" is not an expected value (no-zip, zip).',
+                  'Provided zip_method "zip-error" is not an expected value (tar or tar-bz2).',
                   'Provided workflow "wf-error" is not an expected value (dpx, mkv, mkv-filmscan, mov, mp4, mxf, wav)',
                   'Cannot check for the metadata.csv because the AIPs directory has an error.']
         expected = (None, None, None, None, None, errors)
@@ -88,7 +88,7 @@ class TestCheckArguments(unittest.TestCase):
     def test_extra(self):
         """Test for when there are more arguments than expected (more than 4)"""
         aips_dir = os.path.join(os.getcwd(), 'check_arguments', 'aips_dir')
-        result = check_arguments(['general-aip.py', aips_dir, 'av', 'no-zip', 'mxf', 'extra', 'extra2'])
+        result = check_arguments(['general-aip.py', aips_dir, 'av', 'tar', 'mxf', 'extra', 'extra2'])
         errors = ['Too many script arguments. The maximum expected is 4.']
         expected = (aips_dir, 'av', False, 'mxf', os.path.join(aips_dir, 'metadata.csv'), errors)
         self.assertEqual(expected, result, "Problem with test for extra arguments")

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -94,7 +94,7 @@ class TestFullScript(unittest.TestCase):
         # Runs the script.
         script_path = os.path.join('..', 'general_aip.py')
         aip_dir = os.path.join(os.getcwd(), 'script', 'general', 'aip_directory')
-        printed = subprocess.run(f'python "{script_path}" "{aip_dir}" general zip',
+        printed = subprocess.run(f'python "{script_path}" "{aip_dir}" general tar-bz2',
                                  shell=True, capture_output=True, text=True)
 
         # Test for the script print statements.
@@ -231,7 +231,7 @@ class TestFullScript(unittest.TestCase):
         # Runs the script.
         script_path = os.path.join('..', 'general_aip.py')
         aip_dir = os.path.join(os.getcwd(), 'script', 'web', 'preservation_download')
-        printed = subprocess.run(f'python "{script_path}" "{aip_dir}" web zip',
+        printed = subprocess.run(f'python "{script_path}" "{aip_dir}" web tar-bz2',
                                  shell=True, capture_output=True, text=True)
 
         # Test for the script print statements.
@@ -331,7 +331,7 @@ class TestFullScript(unittest.TestCase):
         # Runs the script.
         script_path = os.path.join('..', 'general_aip.py')
         aip_dir = os.path.join(os.getcwd(), 'script', 'error')
-        printed = subprocess.run(f'python "{script_path}" "{aip_dir}" type_error zip',
+        printed = subprocess.run(f'python "{script_path}" "{aip_dir}" type_error tar',
                                  shell=True, capture_output=True, text=True)
 
         # Test for the script print statements.


### PR DESCRIPTION
Rename to_zip parameter to zip_method and change permitted values to tar and tar-bz2 to be explicit about the zipping desired.

The only change besides the description is in check_arguments()