### PR TITLE
Issue#49 remove emory

### DIFF
--- a/aip_functions.py
+++ b/aip_functions.py
@@ -799,9 +799,6 @@ def structure_directory(aip, staging):
         # Deletion log, created by the script when deleting temp files.
         elif item.startswith(f"{aip.id}_files-deleted_"):
             os.replace(item_path, os.path.join(aip_path, "metadata", item))
-        # Metadata file used by Emory with disk images.
-        elif aip.department == "emory" and item.startswith("EmoryMD"):
-            os.replace(item_path, os.path.join(aip_path, "metadata", item))
         # Website metadata files from downloading WARCs from Archive-It.
         # Hargrett and Russell both have -web- in the AIP ID, but MAGIL does not and can only check for the department.
         elif "-web-" in aip.id and item.endswith(web_metadata):

--- a/general_aip.py
+++ b/general_aip.py
@@ -1,8 +1,6 @@
 """Creates AIPs from folders of digital objects that are ready for ingest into our digital preservation system (ARCHive)
 
 The AIPs may contain one or multiple files of any format.
-The script works with Hargrett and Russell library born-digital IDs,
-Hargrett, MAGIL and Russell web IDs, and Emory disk image IDs.
 
 Parameters:
     aips_directory : required,  folder that contains the folders to be made into AIPs

--- a/stylesheets/fits-to-preservation.xsl
+++ b/stylesheets/fits-to-preservation.xsl
@@ -35,9 +35,6 @@
                     <xsl:if test="not($department='magil')">
                         <xsl:call-template name="relationship-collection" />
                     </xsl:if>
-                    <xsl:if test="$department='emory'">
-						<xsl:call-template name="relationship-repository" />
-					</xsl:if>
                 </premis:object>
             </aip>
             <filelist>
@@ -268,29 +265,6 @@
             </premis:relationship>
         </xsl:if>
     </xsl:template>
-
-
-    <!--aip relationship to repository: PREMIS 1.13 (required if applicable).-->
-	<!--Repository is the two letter code between "emory" and the collection number.-->
-    <xsl:template name="relationship-repository">
-		<premis:relationship>
-            <premis:relationshipType>structural</premis:relationshipType>
-            <premis:relationshipSubType>Is Member Of</premis:relationshipSubType>
-            <premis:relatedObjectIdentifier>
-                <premis:relatedObjectIdentifierType>
-                    <xsl:value-of select="$uri" />
-                </premis:relatedObjectIdentifierType>
-                <premis:relatedObjectIdentifierValue>
-					<xsl:analyze-string select="$aip-id" regex="^emory_([a-z]{{2}})_\d{{2,4}}_\d{{2,4}}">
-						<xsl:matching-substring>
-							<xsl:value-of select="regex-group(1)" />
-						</xsl:matching-substring>
-					</xsl:analyze-string>
-                </premis:relatedObjectIdentifierValue>
-            </premis:relatedObjectIdentifier>
-        </premis:relationship>
-    </xsl:template>
-
 
 <!--..................................................................................................-->
 <!--FILELIST SECTION TEMPLATES -->

--- a/tests/test_structure_directory.py
+++ b/tests/test_structure_directory.py
@@ -278,37 +278,6 @@ class TestStructureDirectory(unittest.TestCase):
         expected = 'Successfully created metadata folder'
         self.assertEqual(expected, result, "Problem with sort_av_mxf, log: MetadataError")
 
-    def test_sort_emory(self):
-        """Test for an AIP which contains an Emory metadata file, which goes in the metadata subfolder"""
-        # Makes test input (AIP instance and AIP directory with files) and runs the function being tested.
-        aips_dir = os.path.join(os.getcwd(), 'structure_directory')
-        staging_dir = os.path.join(os.getcwd(), 'staging_for_tests')
-        aip = AIP(aips_dir, 'emory', None, 'coll-emory', 'folder', 'general', 'emory-aip-1', 'title', 'InC', 1, True)
-        shutil.copytree(os.path.join(aips_dir, 'emory-aip-1_copy'), os.path.join(aips_dir, 'emory-aip-1'))
-        structure_directory(aip, staging_dir)
-
-        # Test for the contents of the AIP folder.
-        aip_path = os.path.join(staging_dir, aips_dir, aip.id)
-        result = make_directory_list(aip_path)
-        expected = [os.path.join(aip_path, 'metadata'),
-                    os.path.join(aip_path, 'metadata', 'EmoryMD_Text.txt'),
-                    os.path.join(aip_path, 'objects'),
-                    os.path.join(aip_path, 'objects', 'Test Dir'),
-                    os.path.join(aip_path, 'objects', 'Test Dir', 'Test Dir Text.txt'),
-                    os.path.join(aip_path, 'objects', 'Text 2.txt'),
-                    os.path.join(aip_path, 'objects', 'Text.txt')]
-        self.assertEqual(expected, result, "Problem with sort Emory metadata, AIP folder")
-
-        # Test for the AIP log: ObjectsError.
-        result = aip.log['ObjectsError']
-        expected = 'Successfully created objects folder'
-        self.assertEqual(expected, result, "Problem with sort Emory metadata, log: ObjectsError")
-
-        # Test for the AIP log: MetadataError.
-        result = aip.log['MetadataError']
-        expected = 'Successfully created metadata folder'
-        self.assertEqual(expected, result, "Problem with sort Emory metadata, log: MetadataError")
-
     def test_sort_files_deleted(self):
         """Test for an AIP which contains a deletion log, which goes in the metadata subfolder"""
         # Makes test input (AIP instance and AIP directory with files) and runs the function being tested.


### PR DESCRIPTION
Emory is no longer using this script or our preservation system. Removed Emory-specific rules for organizing the directory and including a repository relationship in the preservation.xml