### PR TITLE
Issue#14 pandas for check metadata csv

### DIFF
--- a/aip_functions.py
+++ b/aip_functions.py
@@ -10,6 +10,8 @@ import subprocess
 import time
 import xml.etree.ElementTree as et
 import bagit
+import pandas as pd
+
 import configuration as c
 
 
@@ -182,7 +184,7 @@ def check_configuration(aips_dir):
     return errors_list
 
 
-def check_metadata_csv(read_metadata, aips_dir):
+def check_metadata_csv(md_csv, aips_dir):
     """Verify the content of the metadata.csv is correct
 
     - Columns are in the required order
@@ -191,7 +193,7 @@ def check_metadata_csv(read_metadata, aips_dir):
     - The AIPs in the CSV match the folders in the AIPs directory
 
     Parameters:
-        read_metadata : contents of the metadata.csv file, read with the csv library
+        md_csv : path to the metadata.csv file
         aips_dir : the path to the folder which contains the folders to be made into AIPs
 
     Returns:
@@ -203,7 +205,7 @@ def check_metadata_csv(read_metadata, aips_dir):
 
     # Checks that the CSV header row has the required values (case-insensitive).
     # If the header is not correct, returns the error and does not test the column values.
-    header = next(read_metadata)
+    header = next(md_csv)
     header_lowercase = [name.lower() for name in header]
     if header_lowercase != ["department", "collection", "folder", "aip_id", "title", "rights", "version"]:
         errors_list.append("The columns in the metadata.csv do not match the required values or order.")
@@ -216,7 +218,7 @@ def check_metadata_csv(read_metadata, aips_dir):
     csv_dept_list = []
     csv_folder_list = []
     csv_rights_list = []
-    for row in read_metadata:
+    for row in md_csv:
         csv_dept_list.append(row[0])
         csv_folder_list.append(row[2])
         csv_rights_list.append(row[5])

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -208,7 +208,7 @@ def check_metadata_csv(md_csv, aips_dir):
 
     # Checks that the CSV header row has the required values (case-insensitive).
     # If the header is not correct, returns the error and does not test the column values.
-    header = next(md_csv)
+    header = md_df.columns.values.tolist()
     header_lowercase = [name.lower() for name in header]
     if header_lowercase != ["department", "collection", "folder", "aip_id", "title", "rights", "version"]:
         errors_list.append("The columns in the metadata.csv do not match the required values or order.")

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -197,6 +197,7 @@ def check_metadata_csv(md_csv, aips_dir):
         aips_dir : the path to the folder which contains the folders to be made into AIPs
 
     Returns:
+        md_df : pandas.DataFrame with the contents of the metadata csv
         errors_list : a list of errors, or an empty list if there were no errors
     """
 
@@ -249,7 +250,7 @@ def check_metadata_csv(md_csv, aips_dir):
         errors_list.append(f"Folder(s) in aips_directory but not in metadata_csv: {', '.join(dir_only)}.")
 
     # The errors list is empty if there were no errors.
-    return errors_list
+    return md_df, errors_list
 
 
 def combine_metadata(aip, staging):

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -229,30 +229,24 @@ def check_metadata_csv(md_csv, aips_dir):
         if not(right.startswith('https://creativecommons.org') or right.startswith('http://rightsstatements.org')):
             errors_list.append(f"{right} is not Creative Commons or RightsStatement.org.")
 
-    # Checks if there are any duplicate folder names.
+    # Checks if there are any duplicate folder names, which is not permitted.
     duplicate_folders = md_df.loc[md_df['Folder'].duplicated(), 'Folder'].unique()
     if len(duplicate_folders) > 0:
         errors_list.append(f"Duplicate folder(s): {', '.join(duplicate_folders)}.")
 
-    # Makes a list of every folder name in the AIPs directory.
+    # Compares the folders in the metadata csv to the folders in the aips_directory, which should match.
     aips_directory_list = []
     for item in os.listdir(aips_dir):
         if os.path.isdir(os.path.join(aips_dir, item)):
             aips_directory_list.append(item)
-
-    # Checks for any folders that are only in the CSV.
-    just_csv = list(set(csv_folder_list) - set(aips_directory_list))
-    if len(just_csv) > 0:
-        just_csv.sort()
-        for aip_folder in just_csv:
-            errors_list.append(f"{aip_folder} is in metadata.csv and missing from the AIPs directory.")
-
-    # Checks for any folders that are only in the AIPs directory.
-    just_aip_dir = list(set(aips_directory_list) - set(csv_folder_list))
-    if len(just_aip_dir) > 0:
-        just_aip_dir.sort()
-        for aip_folder in just_aip_dir:
-            errors_list.append(f"{aip_folder} is in the AIPs directory and missing from metadata.csv.")
+    aips_df = pd.DataFrame(aips_directory_list, columns=['AIP'])
+    compare_df = md_df.merge(aips_df, left_on='Folder', right_on='AIP', how='outer', indicator=True)
+    md_only = compare_df.loc[compare_df['_merge'] == 'left_only', 'Folder'].tolist()
+    if len(md_only) > 0:
+        errors_list.append(f"Folder(s) in metadata csv but not in aips_directory: {', '.join(md_only)}.")
+    dir_only = compare_df.loc[compare_df['_merge'] == 'right_only', 'AIP'].tolist()
+    if len(dir_only) > 0:
+        errors_list.append(f"Folder(s) in aips_directory but not in metadata_csv: {', '.join(dir_only)}.")
 
     # The errors list is empty if there were no errors.
     return errors_list

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -229,22 +229,16 @@ def check_metadata_csv(md_csv, aips_dir):
         if not(right.startswith('https://creativecommons.org') or right.startswith('http://rightsstatements.org')):
             errors_list.append(f"{right} is not Creative Commons or RightsStatement.org.")
 
-    # The rest of the function tests the folder names.
-    csv_folder_list = md_df['Folder']
+    # Checks if there are any duplicate folder names.
+    duplicate_folders = md_df.loc[md_df['Folder'].duplicated(), 'Folder'].unique()
+    if len(duplicate_folders) > 0:
+        errors_list.append(f"Duplicate folder(s): {', '.join(duplicate_folders)}.")
 
     # Makes a list of every folder name in the AIPs directory.
     aips_directory_list = []
     for item in os.listdir(aips_dir):
         if os.path.isdir(os.path.join(aips_dir, item)):
             aips_directory_list.append(item)
-
-    # Checks for any folder names that are in the CSV more than once.
-    duplicates = [folder for folder in csv_folder_list if csv_folder_list.count(folder) > 1]
-    if len(duplicates) > 0:
-        unique_duplicates = list(set(duplicates))
-        unique_duplicates.sort()
-        for duplicate in unique_duplicates:
-            errors_list.append(f"{duplicate} is in the metadata.csv folder column more than once.")
 
     # Checks for any folders that are only in the CSV.
     just_csv = list(set(csv_folder_list) - set(aips_directory_list))

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -217,30 +217,20 @@ def check_metadata_csv(md_csv, aips_dir):
         errors_list.append("Since the columns are not correct, did not check the column values.")
         return errors_list
 
-    # Makes a list of all values in the department, folder, and rights columns to use for testing.
-    csv_dept_list = []
-    csv_folder_list = []
-    csv_rights_list = []
-    for row in md_csv:
-        csv_dept_list.append(row[0])
-        csv_folder_list.append(row[2])
-        csv_rights_list.append(row[5])
-
     # Checks that the values in the department column match the expected ARCHive groups from the configuration file.
-    unique_departments = list(set(csv_dept_list))
-    unique_departments.sort()
+    unique_departments = md_df['Department'].unique()
     for department in unique_departments:
         if department not in c.GROUPS:
             errors_list.append(f"{department} is not an ARCHive group.")
 
     # Checks that the values in the rights column are either Creative Commons or RightsStatements.org.
-    unique_rights = list(set(csv_rights_list))
-    unique_rights.sort()
+    unique_rights = md_df['Rights'].unique()
     for right in unique_rights:
         if not(right.startswith('https://creativecommons.org') or right.startswith('http://rightsstatements.org')):
             errors_list.append(f"{right} is not Creative Commons or RightsStatement.org.")
 
     # The rest of the function tests the folder names.
+    csv_folder_list = md_df['Folder']
 
     # Makes a list of every folder name in the AIPs directory.
     aips_directory_list = []

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -203,6 +203,9 @@ def check_metadata_csv(md_csv, aips_dir):
     # Starts a list for all encountered errors, so all errors can be checked before returning a result.
     errors_list = []
 
+    # Reads the metadata csv into a df.
+    md_df = pd.read_csv(md_csv)
+
     # Checks that the CSV header row has the required values (case-insensitive).
     # If the header is not correct, returns the error and does not test the column values.
     header = next(md_csv)

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -216,7 +216,7 @@ def check_metadata_csv(md_csv, aips_dir):
         errors_list.append("Required: Department, Collection, Folder, AIP_ID, Title, Rights, Version")
         errors_list.append(f"Current:  {', '.join(header)}")
         errors_list.append("Since the columns are not correct, did not check the column values.")
-        return errors_list
+        return md_df, errors_list
 
     # Checks that the values in the department column match the expected ARCHive groups from the configuration file.
     unique_departments = md_df['Department'].unique()

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -207,11 +207,10 @@ def check_metadata_csv(md_csv, aips_dir):
     # Reads the metadata csv into a df.
     md_df = pd.read_csv(md_csv, dtype=str)
 
-    # Checks that the CSV header row has the required values (case-insensitive).
+    # Checks that the CSV header row has the required values (case-sensitive).
     # If the header is not correct, returns the error and does not test the column values.
     header = md_df.columns.values.tolist()
-    header_lowercase = [name.lower() for name in header]
-    if header_lowercase != ["department", "collection", "folder", "aip_id", "title", "rights", "version"]:
+    if header != ["Department", "Collection", "Folder", "AIP_ID", "Title", "Rights", "Version"]:
         errors_list.append("The columns in the metadata.csv do not match the required values or order.")
         errors_list.append("Required: Department, Collection, Folder, AIP_ID, Title, Rights, Version")
         errors_list.append(f"Current:  {', '.join(header)}")

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -206,6 +206,7 @@ def check_metadata_csv(md_csv, aips_dir):
 
     # Reads the metadata csv into a df.
     md_df = pd.read_csv(md_csv, dtype=str)
+    md_df = md_df.fillna('BLANK')
 
     # Checks that the CSV header row has the required values (case-sensitive).
     # If the header is not correct, returns the error and does not test the column values.

--- a/aip_functions.py
+++ b/aip_functions.py
@@ -205,7 +205,7 @@ def check_metadata_csv(md_csv, aips_dir):
     errors_list = []
 
     # Reads the metadata csv into a df.
-    md_df = pd.read_csv(md_csv)
+    md_df = pd.read_csv(md_csv, dtype=str)
 
     # Checks that the CSV header row has the required values (case-insensitive).
     # If the header is not correct, returns the error and does not test the column values.

--- a/general_aip.py
+++ b/general_aip.py
@@ -65,10 +65,6 @@ a.make_output_directories(configuration.AIP_STAGING, AIP_TYPE)
 CURRENT_AIP = 0
 TOTAL_AIPS = len(os.listdir(AIPS_DIRECTORY)) - 2
 
-# Returns to the beginning of the CSV (the script is at the end because of checking it for errors) and skips the header.
-open_metadata.seek(0)
-next(read_metadata)
-
 # Uses the AIP functions to create an AIP for each folder in the metadata CSV.
 # Checks if the AIP folder is still present before calling the function for the next step
 # in case it was moved due to an error in the previous step.

--- a/general_aip.py
+++ b/general_aip.py
@@ -17,7 +17,6 @@ Returns:
     preservation-xml folder with preservation.xml for each AIP, for reference (a copy is in the AIP)
 """
 
-import csv
 import os
 import shutil
 import sys

--- a/general_aip.py
+++ b/general_aip.py
@@ -43,13 +43,8 @@ if len(configuration_errors) > 0:
         print("   * " + error)
     sys.exit()
 
-# Reads the CSV with the AIP metadata.
-open_metadata = open(aip_metadata_csv)
-read_metadata = csv.reader(open_metadata)
-
-# Verifies the metadata header row has the expected values, departments are all ARCHive groups, and the folders match
-# what is in the AIPs directory. If there are an errors, ends the script.
-metadata_errors = a.check_metadata_csv(read_metadata, AIPS_DIRECTORY)
+# Verifies the metadata csv has the expected values. If there are an errors, ends the script.
+metadata_errors = a.check_metadata_csv(aip_metadata_csv, AIPS_DIRECTORY)
 if len(metadata_errors) > 0:
     print('\nProblems detected with metadata.csv:')
     for error in metadata_errors:

--- a/general_aip.py
+++ b/general_aip.py
@@ -43,8 +43,9 @@ if len(configuration_errors) > 0:
         print("   * " + error)
     sys.exit()
 
-# Verifies the metadata csv has the expected values. If there are an errors, ends the script.
-metadata_errors = a.check_metadata_csv(aip_metadata_csv, AIPS_DIRECTORY)
+# Verifies the metadata csv has the expected values and returns them in a dataframe.
+# If there are an errors, ends the script.
+metadata_df, metadata_errors = a.check_metadata_csv(aip_metadata_csv, AIPS_DIRECTORY)
 if len(metadata_errors) > 0:
     print('\nProblems detected with metadata.csv:')
     for error in metadata_errors:

--- a/general_aip.py
+++ b/general_aip.py
@@ -70,8 +70,8 @@ TOTAL_AIPS = len(metadata_df.index)
 for aip_row in metadata_df.itertuples():
 
     # Makes an instance of the AIP class using metadata from the CSV and global variables.
-    aip = a.AIP(AIPS_DIRECTORY, aip_row.department, WORKFLOW, aip_row.collection_id, aip_row.aip_folder, AIP_TYPE,
-                aip_row.aip_id, aip_row.title, aip_row.rights, aip_row.version, ZIP)
+    aip = a.AIP(AIPS_DIRECTORY, aip_row.Department, WORKFLOW, aip_row.Collection, aip_row.Folder, AIP_TYPE,
+                aip_row.AIP_ID, aip_row.Title, aip_row.Rights, aip_row.Version, ZIP)
 
     # Updates the current AIP number and prints the script progress in the terminal.
     CURRENT_AIP += 1

--- a/general_aip.py
+++ b/general_aip.py
@@ -67,12 +67,11 @@ TOTAL_AIPS = len(metadata_df.index)
 # Uses the AIP functions to create an AIP for each folder in the metadata CSV.
 # Checks if the AIP folder is still present before calling the function for the next step
 # in case it was moved due to an error in the previous step.
-for aip_row in read_metadata:
+for aip_row in metadata_df.itertuples():
 
     # Makes an instance of the AIP class using metadata from the CSV and global variables.
-    department, collection_id, aip_folder, aip_id, title, rights, version = aip_row
-    aip = a.AIP(AIPS_DIRECTORY, department, WORKFLOW, collection_id, aip_folder, AIP_TYPE, aip_id, title, rights,
-                version, ZIP)
+    aip = a.AIP(AIPS_DIRECTORY, aip_row.department, WORKFLOW, aip_row.collection_id, aip_row.aip_folder, AIP_TYPE,
+                aip_row.aip_id, aip_row.title, aip_row.rights, aip_row.version, ZIP)
 
     # Updates the current AIP number and prints the script progress in the terminal.
     CURRENT_AIP += 1
@@ -122,8 +121,5 @@ for aip_row in read_metadata:
     # Adds the packaged AIP to the MD5 manifest in the aips-to-ingest folder.
     if f'{aip.id}_bag' in os.listdir(AIPS_DIRECTORY):
         a.manifest(aip, configuration.AIP_STAGING)
-
-# Closes the metadata CSV.
-open_metadata.close()
 
 print("\nScript is finished running.")

--- a/general_aip.py
+++ b/general_aip.py
@@ -61,9 +61,8 @@ a.make_output_directories(configuration.AIP_STAGING, AIP_TYPE)
 
 # Starts counters for tracking the script progress.
 # Some steps are time-consuming, so this shows the script is not stuck.
-# Subtracts one from the total AIPs count for the aip_log.csv and metadata.csv files.
 CURRENT_AIP = 0
-TOTAL_AIPS = len(os.listdir(AIPS_DIRECTORY)) - 2
+TOTAL_AIPS = len(metadata_df.index)
 
 # Uses the AIP functions to create an AIP for each folder in the metadata CSV.
 # Checks if the AIP folder is still present before calling the function for the next step

--- a/tests/check_metadata_csv/correct_diff_case_metadata.csv
+++ b/tests/check_metadata_csv/correct_diff_case_metadata.csv
@@ -1,4 +1,0 @@
-department,COLLECTION,folder,aip_id,TITLE,Rights,Version
-test,test-coll,aip-1,aip-001,title-1,http://rightsstatements.org/vocab/InC/1.0/,1
-test,test-coll,aip-2,aip-002,title-2,http://rightsstatements.org/vocab/InC/1.0/,1
-test,test-coll,aip-3,aip-003,title-3,http://rightsstatements.org/vocab/InC/1.0/,1

--- a/tests/check_metadata_csv/correct_metadata.csv
+++ b/tests/check_metadata_csv/correct_metadata.csv
@@ -1,0 +1,4 @@
+Department,Collection,Folder,AIP_ID,Title,Rights,Version
+test,t-coll,aip1,aip-01,title-1,http://rightsstatements.org/vocab/InC/1.0/,1
+test,t-coll,aip2,aip-02,title-2,http://rightsstatements.org/vocab/InC/1.0/,1
+test,t-coll,aip3,aip-03,title-3,http://rightsstatements.org/vocab/InC/1.0/,1

--- a/tests/check_metadata_csv/correct_metadata.csv
+++ b/tests/check_metadata_csv/correct_metadata.csv
@@ -1,4 +1,4 @@
 Department,Collection,Folder,AIP_ID,Title,Rights,Version
-test,t-coll,aip1,aip-01,title-1,http://rightsstatements.org/vocab/InC/1.0/,1
-test,t-coll,aip2,aip-02,title-2,http://rightsstatements.org/vocab/InC/1.0/,1
-test,t-coll,aip3,aip-03,title-3,http://rightsstatements.org/vocab/InC/1.0/,1
+test,t-coll,aip-1,aip1,title-1,http://rightsstatements.org/vocab/InC/1.0/,1
+test,t-coll,aip-2,aip2,title-2,http://rightsstatements.org/vocab/InC/1.0/,1
+test,t-coll,aip-3,aip3,title-3,http://rightsstatements.org/vocab/InC/1.0/,1

--- a/tests/check_metadata_csv/correct_same_case_metadata.csv
+++ b/tests/check_metadata_csv/correct_same_case_metadata.csv
@@ -1,4 +1,0 @@
-Department,Collection,Folder,AIP_ID,Title,Rights,Version
-test,test-coll,aip-1,aip-001,title-1,http://rightsstatements.org/vocab/InC/1.0/,1
-test,test-coll,aip-2,aip-002,title-2,http://rightsstatements.org/vocab/InC/1.0/,1
-test,test-coll,aip-3,aip-003,title-3,http://rightsstatements.org/vocab/InC/1.0/,1

--- a/tests/check_metadata_csv/error_columns_metadata.csv
+++ b/tests/check_metadata_csv/error_columns_metadata.csv
@@ -1,4 +1,4 @@
-AIP_ID,Dept,Coll,Current,Title,Rights_Statement,Version
+AIP_ID,Dept,Coll,Current,title,Rights_Statement,Version
 aip-001,test,test-coll,aip-1,title-1,https://creativecommons.org/licenses/by-sa/4.0/,1
 aip-002,test,test-coll,aip-2,title-2,https://creativecommons.org/licenses/by-sa/4.0/,1
 aip-003,test,test-coll,aip-3,title-3,https://creativecommons.org/licenses/by-sa/4.0/,1

--- a/tests/check_metadata_csv/error_columns_metadata.csv
+++ b/tests/check_metadata_csv/error_columns_metadata.csv
@@ -1,4 +1,4 @@
-AIP_ID,Department,Collection,Folder,Title,Rights,Version
+AIP_ID,Dept,Coll,Current,Title,Rights_Statement,Version
 aip-001,test,test-coll,aip-1,title-1,https://creativecommons.org/licenses/by-sa/4.0/,1
 aip-002,test,test-coll,aip-2,title-2,https://creativecommons.org/licenses/by-sa/4.0/,1
 aip-003,test,test-coll,aip-3,title-3,https://creativecommons.org/licenses/by-sa/4.0/,1

--- a/tests/check_metadata_csv/error_csv_only_metadata.csv
+++ b/tests/check_metadata_csv/error_csv_only_metadata.csv
@@ -3,4 +3,3 @@ test,test-coll,aip-1,aip-001,title-1,https://creativecommons.org/licenses/by-sa/
 test,test-coll,aip-2,aip-002,title-2,https://creativecommons.org/licenses/by-sa/4.0/,1
 test,test-coll,aip-3,aip-003,title-3,https://creativecommons.org/licenses/by-sa/4.0/,1
 test,test-coll,aip-4,aip-004,title-4,https://creativecommons.org/licenses/by-sa/4.0/,1
-test,test-coll,aip-5,aip-005,title-5,https://creativecommons.org/licenses/by-sa/4.0/,1

--- a/tests/check_metadata_csv/error_duplicate_metadata.csv
+++ b/tests/check_metadata_csv/error_duplicate_metadata.csv
@@ -1,6 +1,8 @@
 Department,Collection,Folder,AIP_ID,Title,Rights,Version
 test,test-coll,aip-1,aip-001,title-1,https://creativecommons.org/licenses/by-sa/4.0/,1
+test,test-coll,aip-1,aip-001,title-1,https://creativecommons.org/licenses/by-sa/4.0/,1
 test,test-coll,aip-2,aip-002,title-2,https://creativecommons.org/licenses/by-sa/4.0/,1
 test,test-coll,aip-3,aip-003,title-3,https://creativecommons.org/licenses/by-sa/4.0/,1
 test,test-coll,aip-2,aip-004,title-4,https://creativecommons.org/licenses/by-sa/4.0/,1
 test,test-coll,aip-3,aip-005,title-5,https://creativecommons.org/licenses/by-sa/4.0/,1
+test,test-coll,aip-1,aip-001,title-1,https://creativecommons.org/licenses/by-sa/4.0/,1

--- a/tests/test_check_metadata_csv.py
+++ b/tests/test_check_metadata_csv.py
@@ -1,79 +1,98 @@
 """Testing for the function test_check_metadata.csv, which takes data from a read CSV as input,
 tests if it meets UGA requirements, and returns either an empty list (no errors) or a list of errors.
 
-In production, the file must be named metadata.csv, but for testing a prefix is added with the test type."""
+In production, the file must be named metadata.csv, but for testing a prefix is added with the test type.
+"""
 
-import csv
 import os
 import unittest
 from aip_functions import check_metadata_csv
 
 
-def run_function(csv_name):
-    """Reads the CSV, runs the function with the read data, and returns the function output"""
-    aip_dir = os.path.join(os.getcwd(), 'check_metadata_csv')
-    with open(os.path.join(aip_dir, csv_name)) as open_metadata:
-        read_metadata = csv.reader(open_metadata)
-        output = check_metadata_csv(read_metadata, aip_dir)
-    return output
-
-
 class TestCheckMetadataCSV(unittest.TestCase):
 
     def test_correct(self):
-        """Test for a metadata.csv with the correct information (column case matches)"""
-        result = run_function('correct_same_case_metadata.csv')
-        expected = []
-        self.assertEqual(expected, result, "Problem with test for correct_same_case_metadata.csv")
+        """Test for a metadata.csv with the correct information"""
+        # Makes the variable needed for function parameters and runs the function.
+        aip_metadata_csv = os.path.join('check_metadata_csv', 'correct_metadata.csv')
+        metadata_df, metadata_errors = check_metadata_csv(aip_metadata_csv, 'check_metadata_csv')
 
-    def test_correct_case_difference(self):
-        """Test for a metadata.csv with the correct information (column case different)"""
-        result = run_function('correct_diff_case_metadata.csv')
+        # Verifies the df has the expected contents.
+        # Only checking the returned df when there are no errors, since any error will quit the script.
+        df_list = [metadata_df.columns.tolist()] + metadata_df.values.tolist()
+        expected = [['Department', 'Collection', 'Folder', 'AIP_ID', 'Title', 'Rights', 'Version'],
+                    ['test', 't-coll', 'aip-1', 'aip1', 'title-1', 'http://rightsstatements.org/vocab/InC/1.0/', '1'],
+                    ['test', 't-coll', 'aip-2', 'aip2', 'title-2', 'http://rightsstatements.org/vocab/InC/1.0/', '1'],
+                    ['test', 't-coll', 'aip-3', 'aip3', 'title-3', 'http://rightsstatements.org/vocab/InC/1.0/', '1']]
+        self.assertEqual(expected, df_list, "Problem with test for correct, df")
+
+        # Verifies the errors list has the expected values.
         expected = []
-        self.assertEqual(expected, result, "Problem with test for correct_diff_case_metadata.csv")
+        self.assertEqual(expected, metadata_errors, "Problem with test for correct, errors list")
 
     def test_error_columns(self):
         """Test for the column names in metadata.csv not matching the expected values"""
-        result = run_function('error_column_order_metadata.csv')
+        # Makes the variable needed for function parameters and runs the function.
+        aip_metadata_csv = os.path.join('check_metadata_csv', 'error_columns_metadata.csv')
+        metadata_df, metadata_errors = check_metadata_csv(aip_metadata_csv, 'check_metadata_csv')
+
+        # Verifies the errors list has the expected values.
         expected = ['The columns in the metadata.csv do not match the required values or order.',
                     'Required: Department, Collection, Folder, AIP_ID, Title, Rights, Version',
-                    'Current:  AIP_ID, Department, Collection, Folder, Title, Rights, Version',
+                    'Current:  AIP_ID, Dept, Coll, Current, title, Rights_Statement, Version',
                     'Since the columns are not correct, did not check the column values.']
-        self.assertEqual(expected, result, "Problem with test for error, columns")
-
-    def test_error_group(self):
-        """Test for departments in the metadata.csv which are not ARCHive groups (from the configuration file)"""
-        result = run_function('error_group_metadata.csv')
-        expected = ['Brown is not an ARCHive group.', 'banana is not an ARCHive group.']
-        self.assertEqual(expected, result, "Problem with test for error, group")
-
-    def test_error_repeated_folders(self):
-        """Test for AIPs that are in the metadata.csv more than once"""
-        result = run_function('error_repeat_metadata.csv')
-        expected = ['aip-2 is in the metadata.csv folder column more than once.',
-                    'aip-3 is in the metadata.csv folder column more than once.']
-        self.assertEqual(expected, result, "Problem with test for error, repeated folders")
+        self.assertEqual(expected, metadata_errors, "Problem with test for error_columns, errors list")
 
     def test_error_csv_only(self):
         """Test for AIP folders that are only in the metadata.csv and not in the AIPs directory"""
-        result = run_function('error_csv_only_metadata.csv')
-        expected = ['aip-4 is in metadata.csv and missing from the AIPs directory.',
-                    'aip-5 is in metadata.csv and missing from the AIPs directory.']
-        self.assertEqual(expected, result, "Problem with test for error, CSV only")
+        # Makes the variable needed for function parameters and runs the function.
+        aip_metadata_csv = os.path.join('check_metadata_csv', 'error_csv_only_metadata.csv')
+        metadata_df, metadata_errors = check_metadata_csv(aip_metadata_csv, 'check_metadata_csv')
+
+        # Verifies the errors list has the expected values.
+        expected = ['Folder(s) in metadata csv but not in aips_directory: aip-4.']
+        self.assertEqual(expected, metadata_errors, "Problem with test for error_csv_only, errors list")
 
     def test_error_directory_only(self):
         """Test for AIP folders that are only in the AIPs directory and not the metadata.csv"""
-        result = run_function('error_directory_only_metadata.csv')
-        expected = ['aip-1 is in the AIPs directory and missing from metadata.csv.',
-                    'aip-3 is in the AIPs directory and missing from metadata.csv.']
-        self.assertEqual(expected, result, "Problem with test for error, directory only")
+        # Makes the variable needed for function parameters and runs the function.
+        aip_metadata_csv = os.path.join('check_metadata_csv', 'error_directory_only_metadata.csv')
+        metadata_df, metadata_errors = check_metadata_csv(aip_metadata_csv, 'check_metadata_csv')
+
+        # Verifies the errors list has the expected values.
+        expected = ['Folder(s) in aips_directory but not in metadata_csv: aip-1, aip-3.']
+        self.assertEqual(expected, metadata_errors, "Problem with test for error_directory_only, errors list")
+
+    def test_error_duplicate_folders(self):
+        """Test for AIPs that are in the metadata.csv more than once"""
+        # Makes the variable needed for function parameters and runs the function.
+        aip_metadata_csv = os.path.join('check_metadata_csv', 'error_duplicate_metadata.csv')
+        metadata_df, metadata_errors = check_metadata_csv(aip_metadata_csv, 'check_metadata_csv')
+
+        # Verifies the errors list has the expected values.
+        expected = ['Duplicate folder(s): aip-1, aip-2, aip-3.']
+        self.assertEqual(expected, metadata_errors, "Problem with test for error_duplicate_folders, errors list")
+
+    def test_error_group(self):
+        """Test for departments in the metadata.csv which are not ARCHive groups (from the configuration file)"""
+        # Makes the variable needed for function parameters and runs the function.
+        aip_metadata_csv = os.path.join('check_metadata_csv', 'error_group_metadata.csv')
+        metadata_df, metadata_errors = check_metadata_csv(aip_metadata_csv, 'check_metadata_csv')
+
+        # Verifies the errors list has the expected values.
+        expected = ['banana is not an ARCHive group.', 'Brown is not an ARCHive group.']
+        self.assertEqual(expected, metadata_errors, "Problem with test for error_group, errors list")
 
     def test_error_rights(self):
         """Test for rights in the metadata.csv that are not Creative Commons or RightsStatements.org"""
-        result = run_function('error_rights_metadata.csv')
-        expected = [' is not Creative Commons or RightsStatement.org.',
-                    'InC is not Creative Commons or RightsStatement.org.']
-        self.assertEqual(expected, result, "Problem with test for error, rights")
+        # Makes the variable needed for function parameters and runs the function.
+        aip_metadata_csv = os.path.join('check_metadata_csv', 'error_rights_metadata.csv')
+        metadata_df, metadata_errors = check_metadata_csv(aip_metadata_csv, 'check_metadata_csv')
+
+        # Verifies the errors list has the expected values.
+        expected = ['InC is not Creative Commons or RightsStatement.org.',
+                    'BLANK is not Creative Commons or RightsStatement.org.']
+        self.assertEqual(expected, metadata_errors, "Problem with test for error_rights, errors list")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Use pandas instead of iterating on the csv twice to check the metadata.csv for errors and then extract the metadata for each AIP.